### PR TITLE
Presigned URLs by default in GET file, bundle

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -41,7 +41,7 @@ def get(
         per_page: int,
         version: str = None,
         directurls: bool = False,
-        presignedurls: bool = False,
+        presignedurls: bool = True,
         token: str = None,
         start_at: int = 0,
 ):


### PR DESCRIPTION
Closes #3

All clear on [Travis](https://travis-ci.com/HumanCellAtlas/data-store/builds/144417021) and [GitLab](https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/pipelines/20598)