### PR TITLE
Fix check_env.py script

### DIFF
--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -22,6 +22,7 @@ def get_ssm_lambda_environment(stage: str):
 def get_local_lambda_environment():
     env = dict()
     deployment_env = ["ADMIN_USER_EMAILS"]
+    deployment_env += ["DSS_ES_ENDPOINT"]
     deployment_env += os.environ['EXPORT_ENV_VARS_TO_LAMBDA'].split()
     deployment_env.remove('DSS_VERSION')
     for name in deployment_env:
@@ -73,6 +74,6 @@ if __name__ == '__main__':
     missing_keys = missing_local_with_stage(stage=stage, ssm_env=ssm_env, local_env=local_env, filter_env=filter_env)
     different_env_values = different_local_with_stage(stage=stage, ssm_env=ssm_env, local_env=local_env, filter_env=filter_env)
     if any(missing_keys.values()):
-        print(f"Warning: Found missing in variables for : \n{json.dumps(missing_keys)}")
+        print(f"Warning: Found missing env variables between local and {stage}: \n{json.dumps(missing_keys)}")
     if any(different_env_values.values()):
         print(f"Warning: Found different env values between local and {stage}: \n{json.dumps(different_env_values)}")


### PR DESCRIPTION
This updates the script `scripts/check_env.py` so that it gets `DSS_ES_ENDPOINT` from the local lambda environment when updating the lambda deployment environment.

Without this PR, `DSS_ES_ENDPOINT` will never be in the local lambda environment (unless it is explicitly added to `EXPORT_ENV_VARS_TO_LAMBDA`), so `check_env.py` will always fail due to `DSS_ES_ENDPOINT` being in the SSM lambda environment but missing from the local lambda environment.

An alternative approach to this PR would be to add `DSS_ES_ENDPOINT` to the list of variables in `EXPORT_ENV_VARS_TO_LAMBDA`. I am open to implementing that approach as well.

Related to #9