### PR TITLE
DSS Deployment: remove hardcoded parameter values

### DIFF
--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -54,7 +54,7 @@ cat "$config_json" | jq ".stages.$stage.tags.DSS_DEPLOY_ORIGIN=\"$DEPLOY_ORIGIN\
 	.stages.$stage.tags.owner=\"${DSS_INFRA_TAG_OWNER}\" | \
 	.stages.$stage.tags.env=\"${DSS_DEPLOYMENT_STAGE}\""  | sponge "$config_json"
 
-env_json=$(aws ssm get-parameter --name /dcp/dss/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
+env_json=$(aws ssm get-parameter --name /${DSS_PLATFORM}/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
 for var in $(echo $env_json | jq -r keys[]); do
     val=$(echo $env_json | jq .$var)
     cat "$config_json" | jq .stages.$stage.environment_variables.$var="$val" | sponge "$config_json"

--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -54,7 +54,7 @@ cat "$config_json" | jq ".stages.$stage.tags.DSS_DEPLOY_ORIGIN=\"$DEPLOY_ORIGIN\
 	.stages.$stage.tags.owner=\"${DSS_INFRA_TAG_OWNER}\" | \
 	.stages.$stage.tags.env=\"${DSS_DEPLOYMENT_STAGE}\""  | sponge "$config_json"
 
-env_json=$(aws ssm get-parameter --name /${DSS_PLATFORM}/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
+env_json=$(aws ssm get-parameter --name /${DSS_PARAMETER_STORE}/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
 for var in $(echo $env_json | jq -r keys[]); do
     val=$(echo $env_json | jq .$var)
     cat "$config_json" | jq .stages.$stage.environment_variables.$var="$val" | sponge "$config_json"

--- a/daemons/build_deploy_config.sh
+++ b/daemons/build_deploy_config.sh
@@ -44,7 +44,7 @@ cat "$config_json" | jq ".stages.$stage.tags.DSS_DEPLOY_ORIGIN=\"$DEPLOY_ORIGIN\
 	.stages.$stage.tags.owner=\"${DSS_INFRA_TAG_OWNER}\" | \
 	.stages.$stage.tags.env=\"${DSS_DEPLOYMENT_STAGE}\""  | sponge "$config_json"
 
-env_json=$(aws ssm get-parameter --name /dcp/dss/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
+env_json=$(aws ssm get-parameter --name /${DSS_PLATFORM}/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
 for var in $(echo $env_json | jq -r keys[]); do
     val=$(echo $env_json | jq .$var)
     cat "$config_json" | jq .stages.$stage.environment_variables.$var="$val" | sponge "$config_json"

--- a/daemons/build_deploy_config.sh
+++ b/daemons/build_deploy_config.sh
@@ -44,7 +44,7 @@ cat "$config_json" | jq ".stages.$stage.tags.DSS_DEPLOY_ORIGIN=\"$DEPLOY_ORIGIN\
 	.stages.$stage.tags.owner=\"${DSS_INFRA_TAG_OWNER}\" | \
 	.stages.$stage.tags.env=\"${DSS_DEPLOYMENT_STAGE}\""  | sponge "$config_json"
 
-env_json=$(aws ssm get-parameter --name /${DSS_PLATFORM}/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
+env_json=$(aws ssm get-parameter --name /${DSS_PARAMETER_STORE}/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
 for var in $(echo $env_json | jq -r keys[]); do
     val=$(echo $env_json | jq .$var)
     cat "$config_json" | jq .stages.$stage.environment_variables.$var="$val" | sponge "$config_json"

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -6,6 +6,7 @@ The GitLab Token is expected to be stored in AWS secretsmanager with secret id "
 Usage: `scripts/status.py owner repo branch`
 Example: `scripts/status.py HumanCellAtlas data-store master`
 """
+import os
 import json
 import boto3
 import requests
@@ -19,9 +20,11 @@ parser.add_argument("branch", help="Branch to return most recent CI pipeline sta
 args = parser.parse_args()
 
 sm = boto3.client("secretsmanager")
+parameter_store = os.environ.get("DSS_PLATFORM")
+t
 
-gitlab_api = sm.get_secret_value(SecretId="dcp/dss/gitlab-api")['SecretString']
-gitlab_token = sm.get_secret_value(SecretId="dcp/dss/gitlab-token")['SecretString']
+gitlab_api = sm.get_secret_value(SecretId=f"{parameter_store}/gitlab-api")['SecretString']
+gitlab_token = sm.get_secret_value(SecretId=f"{parameter_store}/gitlab-token")['SecretString']
 slug = urllib.parse.quote_plus(f"{args.owner}/{args.repo}")
 r = requests.get(
     f"https://{gitlab_api}/projects/{slug}/pipelines",

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -20,7 +20,7 @@ parser.add_argument("branch", help="Branch to return most recent CI pipeline sta
 args = parser.parse_args()
 
 sm = boto3.client("secretsmanager")
-parameter_store = os.environ.get("DSS_PLATFORM")
+parameter_store = os.environ.get("DSS_PARAMETER_STORE")
 t
 
 gitlab_api = sm.get_secret_value(SecretId=f"{parameter_store}/gitlab-api")['SecretString']

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -21,7 +21,6 @@ args = parser.parse_args()
 
 sm = boto3.client("secretsmanager")
 parameter_store = os.environ.get("DSS_PARAMETER_STORE")
-t
 
 gitlab_api = sm.get_secret_value(SecretId=f"{parameter_store}/gitlab-api")['SecretString']
 gitlab_token = sm.get_secret_value(SecretId=f"{parameter_store}/gitlab-token")['SecretString']


### PR DESCRIPTION
get rid of hardcoded `dcp/dss`, use `DSS_PARAMETER_STORE`

closes #29 