### PR TITLE
DSS Infra: Descriptive API Gateway 

### DIFF
--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -41,6 +41,7 @@ else
            .$stage.rest_api_id = env.api_id | \
            .$stage.region = env.AWS_DEFAULT_REGION | \
            .$stage.api_gateway_stage = env.stage | \
+           .$stage.app_name = env.lambda_name | \
            .$stage.backend = \"api\" | \
            .$stage.chalice_version = \"1.0.1\" | \
            .$stage.lambda_functions = {}" > "$deployed_json"

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -176,7 +176,7 @@ class DSSRequestBodyValidator(RequestBodyValidator):
 
 def create_app():
     app = DSSApp(
-        __name__,
+        app_name=f'dss-{os.environ.get("DSS_DEPLOYMENT_STAGE")}',
         validator_map={
             'body': DSSRequestBodyValidator,
             'parameter': DSSParameterValidator,


### PR DESCRIPTION
this allows for more descriptive names for api-gateway rather than having multiple with the same `dss` label. Allows for faster `api-gateway` API use if/when needed.  

Connected to #33 