### PR TITLE
Update cloud storage metadata keys in storage/identifiers.py

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -494,17 +494,17 @@ paths:
 
         The metadata fields required are:
 
-        - hca-dss-sha256: SHA-256 checksum of the file
+        - dss-sha256: SHA-256 checksum of the file
 
-        - hca-dss-sha1: SHA-1 checksum of the file
+        - dss-sha1: SHA-1 checksum of the file
 
-        - hca-dss-s3_etag: S3 ETAG checksum of the file.  See https://stackoverflow.com/q/12186993 for the
+        - dss-s3_etag: S3 ETAG checksum of the file.  See https://stackoverflow.com/q/12186993 for the
         general algorithm for how checksum is calculated.  For files smaller than 64MB, this is the MD5 checksum
         of the file.  For files larger than 64MB but smaller than 640,000MB, we use 64MB chunks.  For files larger than
         640,000MB, we use a chunk size equal to the total file size divided by 10000, rounded up to the nearest MB.
         MB, in this section, refers to 1,048,576 bytes.  Note that 640,000MB is not the same as 640GB!
 
-        - hca-dss-crc32c: CRC-32C checksum of the file
+        - dss-crc32c: CRC-32C checksum of the file
       parameters:
         - name: uuid
           in: path

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -14,20 +14,20 @@ blob_checksum_format = {
     # These are regular expressions that are used to verify the forms of
     # checksums provided to a `PUT /file/{uuid}` API call. You can see the
     # same ones in the Swagger spec (see definitions.file_version).
-    'hca-dss-crc32c': r'^[a-z0-9]{8}$',
-    'hca-dss-s3_etag': r'^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2'
+    'dss-crc32c': r'^[a-z0-9]{8}$',
+    'dss-s3_etag': r'^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2'
                        r'}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|9'
                        r'9[0-8][0-9]|999[0-9]|10000))?$',
-    'hca-dss-sha1': r'^[a-z0-9]{40}$',
-    'hca-dss-sha256': r'^[a-z0-9]{64}$'
+    'dss-sha1': r'^[a-z0-9]{40}$',
+    'dss-sha256': r'^[a-z0-9]{64}$'
 }
 
 blob_checksum_format_pure = {key: value.strip('$^') for key, value in blob_checksum_format.items()}
 BLOB_KEY_REGEX = re.compile(f'^(blobs)/'
-                            f'({blob_checksum_format_pure["hca-dss-sha256"]}).'
-                            f'({blob_checksum_format_pure["hca-dss-sha1"]}).'
-                            f'({blob_checksum_format_pure["hca-dss-s3_etag"]}).'
-                            f'({blob_checksum_format_pure["hca-dss-crc32c"]})$')
+                            f'({blob_checksum_format_pure["dss-sha256"]}).'
+                            f'({blob_checksum_format_pure["dss-sha1"]}).'
+                            f'({blob_checksum_format_pure["dss-s3_etag"]}).'
+                            f'({blob_checksum_format_pure["dss-crc32c"]})$')
 
 # does not allow caps
 # (though our swagger params allow users to input this, s3 keys are changed to lowercase after ingestion)


### PR DESCRIPTION
This renames cloud upload metadata key names to remove `hca-` prefix from the keys in the cloud storage metadata dictionary.

Related issue: #44

Related CLI PR: DataBiosphere/data-store-cli#17