### PR TITLE
Fix cloud storage metadata keys in swagger

### DIFF
--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -41,9 +41,6 @@ setup_fusillade:
     -   source environment.$CI_COMMIT_REF_NAME
     - fi
     - export ADMIN_USER_EMAILS=test@ucsc.edu
-    - aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-    - aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-    - aws configure set region $AWS_DEFAULT_REGION
     - cat ./roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
     - FUS_STAGE=$DSS_DEPLOYMENT_STAGE
     - python -m json.tool ./temp-roles.json > /dev/null || exit 1

--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -40,6 +40,10 @@ setup_fusillade:
     - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then
     -   source environment.$CI_COMMIT_REF_NAME
     - fi
+    - export ADMIN_USER_EMAILS=test@ucsc.edu
+    - aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+    - aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+    - aws configure set region $AWS_DEFAULT_REGION
     - cat ./roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
     - FUS_STAGE=$DSS_DEPLOYMENT_STAGE
     - python -m json.tool ./temp-roles.json > /dev/null || exit 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,9 +29,6 @@ before_script:
   -   source environment.$CI_COMMIT_REF_NAME
   - fi
   - export ADMIN_USER_EMAILS=test@ucsc.edu
-  - aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-  - aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-  - aws configure set region $AWS_DEFAULT_REGION
   - scripts/dss-ops.py secrets get application_secrets.json > application_secrets.json
   - scripts/dss-ops.py secrets get gcp-credentials.json > gcp-credentials.json
   - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
-image: humancellatlas/dss-build-box
-# The Docker image `humancellatlas/dss-build-box` is created through a manual process from
+image: quay.io/ucsc_cgl/dss-build-box
+# The Docker image `quay.io/ucsc_cgl/dss-build-box` is created through a manual process from
 # `${DSS_HOME}/allspark.Dockerfile`. See the contents of `${DSS_HOME}/allspark.Dockerfile` # creation and usage instructions.
 
 variables:
@@ -7,6 +7,7 @@ variables:
   DSS_ES_TIMEOUT: 30
   DSS_UNITTEST_OPTS: "-v -b"
   GITHUB_API: "https://api.github.com"
+  AWS_DEFAULT_REGION: us-east-1
 
 stages:
   - trufflehog
@@ -27,6 +28,10 @@ before_script:
   - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then
   -   source environment.$CI_COMMIT_REF_NAME
   - fi
+  - export ADMIN_USER_EMAILS=test@ucsc.edu
+  - aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+  - aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+  - aws configure set region $AWS_DEFAULT_REGION
   - scripts/dss-ops.py secrets get application_secrets.json > application_secrets.json
   - scripts/dss-ops.py secrets get gcp-credentials.json > gcp-credentials.json
   - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json

--- a/allspark.Dockerfile
+++ b/allspark.Dockerfile
@@ -5,8 +5,8 @@
 #   `docker push {docker_username}/{tag_key}:{tag_value}`
 # For example,
 #   `docker login
-#   `docker build -f allspark.Dockerfile -t humancellatlas/dss-build-box .`
-#   `docker push humancellatlas/dss-build-box`
+#   `docker build -f allspark.Dockerfile -t quay.io/ucsc_cgl/dss-build-box .`
+#   `docker push quay.io/ucsc_cgl/dss-build-box`
 #
 # Now reference the image in .gitlab-ci.yml with the line:
 #   `image: {docker_username}/{tag_key}:{tag_value}

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -494,17 +494,17 @@ paths:
 
         The metadata fields required are:
 
-        - hca-dss-sha256: SHA-256 checksum of the file
+        - dss-sha256: SHA-256 checksum of the file
 
-        - hca-dss-sha1: SHA-1 checksum of the file
+        - dss-sha1: SHA-1 checksum of the file
 
-        - hca-dss-s3_etag: S3 ETAG checksum of the file.  See https://stackoverflow.com/q/12186993 for the
+        - dss-s3_etag: S3 ETAG checksum of the file.  See https://stackoverflow.com/q/12186993 for the
         general algorithm for how checksum is calculated.  For files smaller than 64MB, this is the MD5 checksum
         of the file.  For files larger than 64MB but smaller than 640,000MB, we use 64MB chunks.  For files larger than
         640,000MB, we use a chunk size equal to the total file size divided by 10000, rounded up to the nearest MB.
         MB, in this section, refers to 1,048,576 bytes.  Note that 640,000MB is not the same as 640GB!
 
-        - hca-dss-crc32c: CRC-32C checksum of the file
+        - dss-crc32c: CRC-32C checksum of the file
       parameters:
         - name: uuid
           in: path


### PR DESCRIPTION
Related to PR databiosphere/data-store-cli#17 which removed the `hca-` prefix from the the cloud storage upload metadata fields.

This closes issue #45