### PR TITLE
Fix environment OIDC group/email claims

### DIFF
--- a/environment
+++ b/environment
@@ -130,8 +130,8 @@ TOKENINFO_FUNC=dss.util.security.verify_jwt
 OIDC_AUDIENCE=https://dss.dev.ucsc-cgp-redwood.org/
 AUTH_URL=https://auth.ucsc.ucsc-cgp-redwood.org
 OPENID_PROVIDER=https://dev-4lyab62k.auth0.com/
-OIDC_EMAIL_CLAIM="${AUTH_URL}/email"
-OIDC_GROUP_CLAIM="${AUTH_URL}/group"
+OIDC_EMAIL_CLAIM="${OIDC_AUDIENCE}/email"
+OIDC_GROUP_CLAIM="${OIDC_AUDIENCE}/group"
 
 NOTIFY_URL=https://${API_DOMAIN_NAME}/internal/notify
 DSS_AUTHORIZED_GOOGLE_PROJECT_DOMAIN_ARRAY=(

--- a/environment
+++ b/environment
@@ -127,7 +127,7 @@ API_DOMAIN_NAME="dss.${DSS_DEPLOYMENT_STAGE}.ucsc-cgp-redwood.org"
 TOKENINFO_FUNC=dss.util.security.verify_jwt
 # TODO remove https://dev.data.humancellatlas.org/ from OIDC_AUDIENCE once seperate deployments are made
 
-OIDC_AUDIENCE=https://dss.dev.ucsc-cgp-redwood.org/
+OIDC_AUDIENCE=https://dss.dev.ucsc-cgp-redwood.org
 AUTH_URL=https://auth.ucsc.ucsc-cgp-redwood.org
 OPENID_PROVIDER=https://dev-4lyab62k.auth0.com/
 OIDC_EMAIL_CLAIM="${OIDC_AUDIENCE}/email"


### PR DESCRIPTION
This PR updates the `environment` file to use `OIDC_AUDIENCE` to assemble email/group claim names, instead of `AUTH_URL`. This makes the `environment` file consistent with DataBiosphere/data-store-cli#11 

Close #60 