### PR TITLE
DSS Infra: add platform to CI/CD

### DIFF
--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -16,12 +16,8 @@
       "Resource": [
         "arn:aws:s3:::$DSS_S3_BUCKET/*",
         "arn:aws:s3:::$DSS_S3_BUCKET_TEST/*",
-        "arn:aws:s3:::$DSS_S3_BUCKET_INTEGRATION/*",
-        "arn:aws:s3:::$DSS_S3_BUCKET_STAGING/*",
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET/*",
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST/*",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_INTEGRATION/*",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_STAGING/*",
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST_USER/*"
       ]
     },
@@ -36,12 +32,8 @@
       "Resource": [
         "arn:aws:s3:::$DSS_S3_BUCKET",
         "arn:aws:s3:::$DSS_S3_BUCKET_TEST",
-        "arn:aws:s3:::$DSS_S3_BUCKET_INTEGRATION",
-        "arn:aws:s3:::$DSS_S3_BUCKET_STAGING",
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_INTEGRATION",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_STAGING"
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST"
       ]
     },
     {
@@ -54,13 +46,9 @@
         "arn:aws:s3:::$DSS_S3_BUCKET", "arn:aws:s3:::$DSS_S3_BUCKET/*",
         "arn:aws:s3:::$DSS_S3_BUCKET_TEST", "arn:aws:s3:::$DSS_S3_BUCKET_TEST/*",
         "arn:aws:s3:::$DSS_S3_BUCKET_TEST_FIXTURES", "arn:aws:s3:::$DSS_S3_BUCKET_TEST_FIXTURES/*",
-        "arn:aws:s3:::$DSS_S3_BUCKET_INTEGRATION", "arn:aws:s3:::$DSS_S3_BUCKET_INTEGRATION/*",
-        "arn:aws:s3:::$DSS_S3_BUCKET_STAGING", "arn:aws:s3:::$DSS_S3_BUCKET_STAGING/*",
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET", "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET/*",
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST", "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST/*",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST_USER", "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST_USER/*",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_INTEGRATION", "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_INTEGRATION/*",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_STAGING", "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_STAGING/*"
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST_USER", "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST_USER/*"
       ]
     },
     {
@@ -86,8 +74,6 @@
       "Resource": [
         "arn:aws:lambda:*:$account_id:function:dss-*",
         "arn:aws:es:*:$account_id:domain/dss-index-dev", "arn:aws:es:*:$account_id:domain/dss-index-dev/*",
-        "arn:aws:es:*:$account_id:domain/dss-index-integration", "arn:aws:es:*:$account_id:domain/dss-index-integration/*",
-        "arn:aws:es:*:$account_id:domain/dss-index-staging", "arn:aws:es:*:$account_id:domain/dss-index-staging/*",
         "arn:aws:sns:*:$account_id:dss-*",
         "arn:aws:sns:*:$account_id:domovoi-s3-events-*",
         "arn:aws:states:*:$account_id:*:dss-*"
@@ -107,11 +93,7 @@
         "arn:aws:dynamodb:*:$account_id:table/scalability_test_result",
         "arn:aws:dynamodb:*:$account_id:table/scalability_test/stream/*",
         "arn:aws:dynamodb:*:$account_id:table/dss-async-state-dev",
-        "arn:aws:dynamodb:*:$account_id:table/dss-async-state-integration",
-        "arn:aws:dynamodb:*:$account_id:table/dss-async-state-staging",
         "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-dev",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-integration",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-staging",
         "arn:aws:dynamodb:*:$account_id:table/dss-collections-db-*"
       ]
     },
@@ -171,9 +153,7 @@
       ],
       "Resource": [
         "arn:aws:sqs:*:$account_id:dss-notify-test-*",
-        "arn:aws:sqs:*:$account_id:dss-notify-dev-*",
-        "arn:aws:sqs:*:$account_id:dss-notify-integration-*",
-        "arn:aws:sqs:*:$account_id:dss-notify-staging-*"
+        "arn:aws:sqs:*:$account_id:dss-notify-dev-*"
       ]
     },
     {

--- a/scripts/authorize_aws_deploy.sh
+++ b/scripts/authorize_aws_deploy.sh
@@ -13,7 +13,7 @@ if [[ $# != 2 ]]; then
     echo "test and deploy the DSS application. Run this script using privileged"
     echo "(IAM write access) IAM credentials."
     echo "Usage: $(basename $0) iam-principal-type iam-principal-name"
-    echo "Example: $(basename $0) user hca-test"
+    echo "Example: $(basename $0) group travis-ci"
     exit 1
 fi
 

--- a/scripts/authorize_aws_deploy.sh
+++ b/scripts/authorize_aws_deploy.sh
@@ -17,6 +17,7 @@ if [[ $# != 2 ]]; then
     exit 1
 fi
 
+export platform=$DSS_PLATFORM
 export iam_principal_type=$1 iam_principal_name=$2
 export account_id=$(aws sts get-caller-identity | jq -r .Account)
 policy_json="$(dirname $0)/../iam/policy-templates/ci-cd.json"
@@ -38,7 +39,7 @@ envsubst_vars='$DSS_DEPLOYMENT_STAGE
 
 aws iam put-${iam_principal_type}-policy \
     --${iam_principal_type}-name $iam_principal_name \
-    --policy-name hca-dss-ci-cd \
+    --policy-name ${platform}-dss-ci-cd \
     --policy-document file://<(cat "$policy_json" | \
                                    envsubst "$envsubst_vars" | \
                                    jq -c 'del(.Statement[].Sid)')


### PR DESCRIPTION
removes `hca` hardcode from policy, uses env `DSS_PLATFORM` 