### PR TITLE
Add stage to API gateway deploy name

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -145,7 +145,7 @@ def analytics_reply(method, uri):
 
 
 def get_chalice_app(flask_app) -> DSSChaliceApp:
-    app = DSSChaliceApp(app_name=flask_app.name, configure_logs=False)
+    app = DSSChaliceApp(app_name=f"{flask_app.name}-{os.environ['DSS_DEPLOYMENT_STAGE']}", configure_logs=False)
 
     @time_limited(app)
     def dispatch(*args, **kwargs):

--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -52,7 +52,8 @@ cat "$config_json" | jq ".stages.$stage.tags.DSS_DEPLOY_ORIGIN=\"$DEPLOY_ORIGIN\
 	.stages.$stage.tags.service=\"${DSS_INFRA_TAG_SERVICE}\"  | \
 	.stages.$stage.tags.project=\"$DSS_INFRA_TAG_PROJECT\" | \
 	.stages.$stage.tags.owner=\"${DSS_INFRA_TAG_OWNER}\" | \
-	.stages.$stage.tags.env=\"${DSS_DEPLOYMENT_STAGE}\""  | sponge "$config_json"
+	.stages.$stage.tags.env=\"${DSS_DEPLOYMENT_STAGE}\" | \
+	.stages.$stage.app_name=\"env.lambda_name\"" | sponge "$config_json"
 
 env_json=$(aws ssm get-parameter --name /${DSS_PARAMETER_STORE}/${DSS_DEPLOYMENT_STAGE}/environment | jq -r .Parameter.Value)
 for var in $(echo $env_json | jq -r keys[]); do


### PR DESCRIPTION
This fixes the changes added by #32 by specifying the `app_name` kwarg to Chalice instead of Connexion.