### PR TITLE
Fix swagger auth script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,18 +255,26 @@ The following environment variables must be set to enable user authentication an
 Also update `authorizationUrl` in `dss-api.yml` to point to an authorization endpoint that will return
 a valid JWT.
 
-Optional: To configure a custom swagger auth before deployment run:
 
-    python scripts/swagger_auth.py -c='{"/path": "call"}'
+#### Updating Swagger Authentication
 
-Alternatively, to configure auth for all swagger endpoints, you can run:
+It is optional to configure custom authentication and authorizatoin in a swagger file before deploying the
+data store. This can be done with the script `scripts/swagger_auth.py`. This script will load the swagger YML
+file, modify or add auth sections in the YML file, and add auth to various API endpoints.
+
+Auth is added to API endpoints using a key-value dictionary, where the keys are API endpoints and the values are
+HTTP actions taken on the endpoint, such as "put" and "get". The configuration dictionary can be specified on the
+command line or stored in a file.  To pass a configuration on the command line, use the `--config_security` or `-c`
+flag, and pass the values in a list of strings. For example:
+
+    python scripts/swagger_auth.py -c='{"/path": ["call"]}'
+
+Alternatively, auth can be set for all swagger endpoints by passing the `--secure` flag:
 
     python scripts/swagger_auth.py --secure
 
-Note: Removing auth from endpoints will currently break tests, however adding auth should be fine
+Note that **removing** auth from endpoints will currently break tests, however adding auth should be fine
 (`make test` should run successfully).
-
-Note: The auth config file for deployment can also be set in `environment.local` with `AUTH_CONFIG_FILE`.
 
 #### Configure Email Notifications
 

--- a/scripts/swagger_auth.py
+++ b/scripts/swagger_auth.py
@@ -175,7 +175,7 @@ def main(argv=sys.argv[1:]):
                         help='Change the swagger file to include auth on all endpoints.')
     parser.add_argument('-t', '--travis', dest="travis", action='store_true', default=False,
                         help='Run on travis to check that swagger has default auth.')
-    parser.add_argument('-n', '--auth-name', dest="auth_name", default="dcpAuth",
+    parser.add_argument('-n', '--auth-name', dest="auth_name", default="OauthSecurity",
                         help='The name of the security definition being added to protect endpoints.')
 
     o = parser.parse_args(argv)

--- a/scripts/swagger_auth.py
+++ b/scripts/swagger_auth.py
@@ -35,7 +35,7 @@ full_auth = {"/search": ["post"],
 
 
 class SecureSwagger(object):
-    def __init__(self, infile: str=None, outfile: str=None, config: dict=None):
+    def __init__(self, infile: str=None, outfile: str=None, auth_name: str=None, config: dict=None):
         """
         A class for modifying a swagger yml file with auth on endpoints specified in
         a config file.
@@ -52,6 +52,7 @@ class SecureSwagger(object):
         self.infile = infile or os.path.join(pkg_root, 'dss-api.yml')
         self.intermediate_file = os.path.join(pkg_root, 'tmp.yml')
         self.outfile = outfile or os.path.join(pkg_root, 'dss-api.yml')
+        self.auth_name = auth_name
         self.config = default_auth if config is None else config
 
         for endpoint in self.config:
@@ -127,13 +128,13 @@ class SecureSwagger(object):
             with open(self.infile, 'r') as r:
                 for line in r:
                     # ignore security lines already in the swagger yml
-                    if not (line.startswith('      security:') or line.startswith('        - dcpAuth: []')):
+                    if not (line.startswith('      security:') or line.startswith(f'        - {self.auth_name}: []')):
 
                         w.write(line)
                         # returns true based on config file paths
                         if self.security_line(line, checking_flags=True):
                             w.write('      security:\n')
-                            w.write('        - dcpAuth: []\n')
+                            w.write(f'        - {self.auth_name}: []\n')
 
         # the contents of the intermediate file become the contents of the output file
         if os.path.exists(self.outfile):
@@ -174,13 +175,16 @@ def main(argv=sys.argv[1:]):
                         help='Change the swagger file to include auth on all endpoints.')
     parser.add_argument('-t', '--travis', dest="travis", action='store_true', default=False,
                         help='Run on travis to check that swagger has default auth.')
+    parser.add_argument('-n', '--auth-name', dest="auth_name", default="dcpAuth",
+                        help='The name of the security definition being added to protect endpoints.')
+
     o = parser.parse_args(argv)
 
     if o.travis:
         ensure_auth_defaults_are_still_set()
     else:
         config = full_auth if o.secure else o.config_security
-        s = SecureSwagger(o.input_swagger, o.output_swagger, config)
+        s = SecureSwagger(o.input_swagger, o.output_swagger, o.auth_name, config)
         s.make_swagger_from_authconfig()
 
 


### PR DESCRIPTION
This PR updates the Readme section about swagger auth, and the script used to update swagger auth.

Summary of readme changes:
- clarify language and descriptions
- update and fix example call to swagger auth script

Summary of script changes:
- add an "auth name" for specifying the name of the auth mechanism, instead of using the hard-coded `dcpAuth`

closes #105 