### PR TITLE
Trufflehog gitdb dependency fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ before_script:
 trufflehog:
   stage: trufflehog
   script:
-    - pip install trufflehog
+    - pip install gitdb2==3.0.0 truffleHog==2.0.99 # https://github.com/dxa4481/truffleHog/issues/200
     - wget -O regex.json https://raw.githubusercontent.com/HumanCellAtlas/dcplib/master/components/trufflehog_regex_patterns.json
     - trufflehog --regex --rules regex.json --entropy=False https://github.com/DataBiosphere/data-store.git
 


### PR DESCRIPTION
gitdb upgrade to 3.0.2 breaks trufflehog's imports

so we need to pin gitdb2 to a version that doesn't break trufflehog's imports, namely 3.0.0

    pip install gitdb2==3.0.0 truffleHog==2.0.99

instead of

    pip install trufflehog

Also see https://github.com/dxa4481/truffleHog/issues/200

Closes #107 