### PR TITLE
DSS Auth: Improve organization and docstrings

### DIFF
--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -35,14 +35,7 @@ class Auth0(Authorize):
             executed_method(*args, **kwargs)
 
     def _create(self, *args, **kwargs):
-        # Create access is granted to users who are
-        # members of the appropriate group.
-        # OIDC group claim set in configuration.
-        # (authentication-based authorization)
-        self.assert_required_parameters(kwargs, ['security_groups', 'security_token'])
-        groups = kwargs.get('security_groups')
-        token = kwargs.get('security_token')
-        self.assert_authorized_group(groups, token)
+        # Requires checking group
         return
 
     def _read(self, *args, **kwargs):

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -6,7 +6,7 @@ from .authorize import Authorize
 
 class Auth0(Authorize):
     """
-    Implements the Auth0 security flow, which implents different
+    Implements the Auth0 security flow, which implements different
     authorization checks based on whether operations are
     create/read/update/delete operations.
     """

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -34,7 +34,6 @@ class Auth0(Authorize):
             executed_method = self.valid_methods[requested_method]
             executed_method(*args, **kwargs)
 
-
     def _create(self, *args, **kwargs):
         # Create access is granted to users who are
         # members of the appropriate group.
@@ -45,7 +44,6 @@ class Auth0(Authorize):
         token = kwargs.get('security_token')
         self.assert_authorized_group(groups, token)
         return
-
 
     def _read(self, *args, **kwargs):
         # Data is public by default
@@ -59,13 +57,10 @@ class Auth0(Authorize):
         # both the decorator and the decorated function,
         # so that's how we can get requested UUID
 
-
     def _update(self, *args, **kwargs):
         # Requires checking ownership of UUID
         pass
 
-
     def _delete(self, *args, **kwargs):
         # Requires checking ownership of UUID
         pass
-

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -19,9 +19,13 @@ class Fusillade(Authorize):
 
     def security_flow(self, *args, **kwargs):
         """
-        This method maps out security flow for Auth with Fusillade
-        Current implimentation of Fusillade 2.0 requires principals, actions, and resources
-        for all evaluation requests
+        This method maps out security flow for Auth with Fusillade.
+
+        The current implementation of Fusillade (2.0+) uses three pieces of information
+        to evaluate authorization: principals, actions, and resources.
+
+        However, we have overridden this with a simpler authentication-based
+        authorization layer that just checks for membership in a group.
         """
         # verify JWT was populated correctly
         self.assert_required_parameters(kwargs, ['security_groups', 'security_token'])
@@ -29,7 +33,11 @@ class Fusillade(Authorize):
         token = kwargs.get('security_token')
         self.assert_authorized_group(groups, token)
 
-        return  # we actually dont want to use this evaluation method at the moment, so just skip.
+        return
+        
+        # If we were using Fusillade's evaluate endpoint,
+        # this is where we would extract relevant information
+        # from the security decorator.
         self.assert_required_parameters(kwargs, ['principal', 'actions', 'resource'])
         self.assert_authorized(kwargs['principal'], kwargs['actions'], kwargs['resources'])
 

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -34,7 +34,7 @@ class Fusillade(Authorize):
         self.assert_authorized_group(groups, token)
 
         return
-        
+
         # If we were using Fusillade's evaluate endpoint,
         # this is where we would extract relevant information
         # from the security decorator.

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -100,7 +100,12 @@ def assert_authorized_issuer(token: typing.Mapping[str, typing.Any]) -> None:
 
 
 def assert_security(*decorator_args, **decorator_kwargs):
+    # Note: we use 3 total layers of function wrappers here,
+    # not the usual 2 when wrapping functions, because the
+    # wrappers we are defining take *args and **kwargs.
     def real_decorator(func):
+        # Use of functools.wraps ensures that function names
+        # and docstrings are passed through correctly.
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             decorator_kwargs.update(kwargs)


### PR DESCRIPTION
What's done in this PR:

- Improvements to docstrings in security utils and auth utils

- Renaming and improving order of methods in Auth0 class

- Moving assert authorized group back into dss.util.security (used by multiple Auth classes)

- Fixing test

What's not done in this PR:

- Auth0 methods for CRUD security flow are still stub methods, they will be filled in later