### PR TITLE
DSS Auth: Move assert_authorized_group back to dss.util.security

### DIFF
--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -27,7 +27,10 @@ class Fusillade(Authorize):
         self.assert_required_parameters(kwargs, ['security_groups', 'security_token'])
         groups = kwargs.get('security_groups')
         token = kwargs.get('security_token')
-        self.assert_authorized_group(groups, token)
+
+        # Import when this method is called, not when it is defined, to avoid circular imports
+        from ..security import assert_authorized_group
+        assert_authorized_group(groups, token)
 
         return  # we actually dont want to use this evaluation method at the moment, so just skip.
         self.assert_required_parameters(kwargs, ['principal', 'actions', 'resource'])
@@ -45,9 +48,3 @@ class Fusillade(Authorize):
         resp_json = resp.json()
         if not resp_json.get('result'):
             raise DSSForbiddenException(title=f"User is not authorized to access this resource:\n{resp_json}")
-
-    def assert_authorized_group(self, group: typing.List[str], token: dict) -> None:
-        if token.get(Config.get_OIDC_group_claim()) in group:
-            return
-        logger.info(f"User not in authorized group: {group}, {token}")
-        raise DSSForbiddenException()

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -13,7 +13,6 @@ from flask import request
 
 from dss import Config
 from dss.error import DSSForbiddenException, DSSException
-from dss.util.auth import AuthWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +50,7 @@ def get_public_keys(openid_provider):
 
 
 def verify_jwt(token: str) -> typing.Optional[typing.Mapping]:
+    """Internal method used by Connexion to verify JWT tokens"""
     try:
         unverified_token = jwt.decode(token, verify=False)
     except jwt.DecodeError:
@@ -77,6 +77,7 @@ def verify_jwt(token: str) -> typing.Optional[typing.Mapping]:
 
 
 def get_token_email(token_info: typing.Mapping[str, typing.Any]) -> str:
+    """Get the email from a JWT token"""
     try:
         email_claim = Config.get_OIDC_email_claim()
         return token_info.get(email_claim) or token_info['email']
@@ -86,7 +87,8 @@ def get_token_email(token_info: typing.Mapping[str, typing.Any]) -> str:
 
 def assert_authorized_issuer(token: typing.Mapping[str, typing.Any]) -> None:
     """
-    Must be either `Config.get_openid_provider()` or in `Config.get_trusted_google_projects()`
+    Ensure that a JWT token contains a valid issuer under the "iss" key.
+    Must be either `Config.get_openid_provider()` or in `Config.get_trusted_google_projects()`.
     :param token: dict
     """
     issuer = token['iss']
@@ -98,6 +100,16 @@ def assert_authorized_issuer(token: typing.Mapping[str, typing.Any]) -> None:
     logger.info(f"Token issuer not authorized: {issuer}")
     raise DSSForbiddenException()
 
+
+def assert_authorized_group(self, group: typing.List[str], token: dict) -> None:
+    """Assert that a JWT token contains the given group under the group claim key"""
+    if token.get(Config.get_OIDC_group_claim()) in group:
+        return
+    logger.info(f"User not in authorized group: {group}, {token}")
+    raise DSSForbiddenException()
+
+
+from dss.util.auth import AuthWrapper
 
 def assert_security(*decorator_args, **decorator_kwargs):
     def real_decorator(func):

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -13,6 +13,7 @@ from flask import request
 
 from dss import Config
 from dss.error import DSSForbiddenException, DSSException
+from dss.util.auth import AuthWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -108,8 +109,6 @@ def assert_authorized_group(self, group: typing.List[str], token: dict) -> None:
     logger.info(f"User not in authorized group: {group}, {token}")
     raise DSSForbiddenException()
 
-
-from dss.util.auth import AuthWrapper
 
 def assert_security(*decorator_args, **decorator_kwargs):
     def real_decorator(func):

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -102,7 +102,7 @@ def assert_authorized_issuer(token: typing.Mapping[str, typing.Any]) -> None:
     raise DSSForbiddenException()
 
 
-def assert_authorized_group(self, group: typing.List[str], token: dict) -> None:
+def assert_authorized_group(group: typing.List[str], token: dict) -> None:
     """Assert that a JWT token contains the given group under the group claim key"""
     if token.get(Config.get_OIDC_group_claim()) in group:
         return

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,7 +99,7 @@ class TestUrlBuilder(unittest.TestCase):
 
 @testmode.standalone
 class TestSecurity(unittest.TestCase):
-    fus_handler = Fusillade()
+    """Test the security utility methods found in dss.util.security"""
 
     @classmethod
     def setUpClass(cls):
@@ -131,7 +131,7 @@ class TestSecurity(unittest.TestCase):
                              ]
         for token_info in valid_token_infos:
             with self.subTest(token_info):
-                self.fus_handler.assert_authorized_group(['hca', 'public'], token_info)
+                security.assert_authorized_group(['hca', 'public'], token_info)
 
     def test_not_authorizated_group(self):
         invalid_token_info = [{'sub': "travis-test@human-cell-atlas-travis-test.gmail.com"},
@@ -143,7 +143,7 @@ class TestSecurity(unittest.TestCase):
         for token_info in invalid_token_info:
             with self.subTest(token_info):
                 with self.assertRaises(DSSForbiddenException):
-                    self.fus_handler.assert_authorized_group(['hca'], token_info)
+                    security.assert_authorized_group(['hca'], token_info)
 
     @mock.patch('dss.Config._OIDC_AUDIENCE', new=["https://dev.data.humancellatlas.org/",
                                                   "https://data.humancellatlas.org/"])


### PR DESCRIPTION
This PR moves the `assert_authorized_group` out of the Fusillade Auth class and back to `dss.util.security`, and fixes the order of imports so there are no conflicts.

This is necessary to do because checking that a group is present under a group claim in a JWT is a common operation that other auth layers besides Fusillade will want to be able to do.

This also fixes the `assert_authorized_group` test.