### PR TITLE
DSS Auth: Improve assert security wrapper argument handling

### DIFF
--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -24,7 +24,7 @@ class Fusillade(Authorize):
         for all evaluation requests
         """
         # Get token
-        decorator_kwargs['security_token'] = request.token_info
+        kwargs['security_token'] = request.token_info
 
         # Set security_groups using first argument, if kwarg not present
         if kwargs.get('security_groups') is None:

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -30,7 +30,7 @@ class Fusillade(Authorize):
 
         # Set security_groups using first argument, if kwarg not present
         if kwargs.get('security_groups') is None:
-             kwargs['security_groups'] = args[0]
+            kwargs['security_groups'] = args[0]
 
         # Verify JWT was populated correctly
         self.assert_required_parameters(kwargs, ['security_groups', 'security_token'])

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -23,7 +23,14 @@ class Fusillade(Authorize):
         Current implimentation of Fusillade 2.0 requires principals, actions, and resources
         for all evaluation requests
         """
-        # verify JWT was populated correctly
+        # Get token
+        decorator_kwargs['security_token'] = request.token_info
+
+        # Set security_groups using first argument, if kwarg not present
+        if kwargs.get('security_groups') is None:
+             kwargs['security_groups'] = args[0]
+
+        # Verify JWT was populated correctly
         self.assert_required_parameters(kwargs, ['security_groups', 'security_token'])
         groups = kwargs.get('security_groups')
         token = kwargs.get('security_token')

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -2,6 +2,8 @@ import logging
 import typing
 import requests
 
+from flask import request
+
 from dss import Config
 from dss.error import DSSForbiddenException
 from .authorize import Authorize

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -108,8 +108,12 @@ def assert_security(*decorator_args, **decorator_kwargs):
             decorator_kwargs.update(kwargs)
             # Wrapper function args get turned into kwargs, then go into decorator kwargs
             sig = inspect.signature(wrapper)
-            for i, p in enumerate(sig._parameters):
-                decorator_kwargs[p] = args[i]
+            for i, p in enumerate(list(sig._parameters)):
+                try:
+                    decorator_kwargs[p] = args[i]
+                except IndexError:
+                    # Corner case: unspecified positional arg, using default value
+                    pass
             # Pass all args/kwargs to AuthWrapper
             authz_handler = AuthWrapper()
             authz_handler.security_flow(*decorator_args, **decorator_kwargs)

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -108,7 +108,7 @@ def assert_security(*decorator_args, **decorator_kwargs):
             decorator_kwargs.update(kwargs)
             # Wrapper function args get turned into kwargs, then go into decorator kwargs
             sig = inspect.signature(wrapper)
-            for i,p in enumerate(sig._parameters):
+            for i, p in enumerate(sig._parameters):
                 decorator_kwargs[p] = args[i]
             # Pass all args/kwargs to AuthWrapper
             authz_handler = AuthWrapper()


### PR DESCRIPTION
This PR adds and removes code:

- Removes code that expects security decorator to have `security_token` and `security_groups` keyword arguments (security decorators need to be flexible, and therefore need to place no requirements on user-provided input arguments). Let the wrapped Auth classes handle kwargs.

- Adds code to turn function arguments into function keyword arguments. This is so that the positional input arguments to `put(uuid, json_request_body, version)` will be turned into keyword arguments like `{uuid: "abc-123", json_request_body: "{'foo':'bar'}", version: "2000-01-01"}`

Closes #114 