### PR TITLE
DSS Auth: Update to Terraformed Client

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -49,7 +49,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(['hca'])
+@security.assert_security(['dbio'])
 def list_collections(per_page: int, start_at: int = 0):
     """
     Return a list of a user's collections.
@@ -87,7 +87,7 @@ def list_collections(per_page: int, start_at: int = 0):
 
 
 @dss_handler
-@security.assert_security(['hca'])
+@security.assert_security(['dbio'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)
@@ -97,7 +97,7 @@ def get(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(['hca'])
+@security.assert_security(['dbio'])
 def put(json_request_body: dict, replica: str, uuid: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = dict(json_request_body, owner=authenticated_user_email)
@@ -118,7 +118,7 @@ def put(json_request_body: dict, replica: str, uuid: str, version: str):
 
 
 @dss_handler
-@security.assert_security(['hca'])
+@security.assert_security(['dbio'])
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 
@@ -157,7 +157,7 @@ def _dedpuplicate_contents(contents: List) -> List:
 
 
 @dss_handler
-@security.assert_security(['hca'])
+@security.assert_security(['dbio'])
 def delete(uuid: str, replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -188,7 +188,7 @@ def _verify_checkout(
 
 
 @dss_handler
-@security.assert_security(['hca'])
+@security.assert_security(['dbio'])
 def put(uuid: str, json_request_body: dict, version: str):
     class CopyMode(Enum):
         NO_COPY = auto()

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -19,7 +19,7 @@ from dss.config import SUBSCRIPTION_LIMIT
 logger = logging.getLogger(__name__)
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 
@@ -45,7 +45,7 @@ def get(uuid: str, replica: str):
     return jsonify(source), requests.codes.okay
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     es_client = ElasticsearchClient.get()
@@ -66,7 +66,7 @@ def find(replica: str):
     return jsonify(full_response), requests.codes.okay
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     uuid = str(uuid4())
     es_query = json_request_body['es_query']
@@ -153,7 +153,7 @@ def put(json_request_body: dict, replica: str):
     return jsonify(dict(uuid=uuid)), requests.codes.created
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -17,7 +17,7 @@ from dss.subscriptions_v2 import (SubscriptionData,
                                   count_subscriptions_for_owner)
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)
@@ -28,7 +28,7 @@ def get(uuid: str, replica: str):
     return subscription, requests.codes.ok
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     subscriptions = get_subscriptions_for_owner(Replica[replica], owner)
@@ -39,7 +39,7 @@ def find(replica: str):
     return {'subscriptions': subscriptions}, requests.codes.ok
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     owner = security.get_token_email(request.token_info)
     if count_subscriptions_for_owner(Replica[replica], owner) > SUBSCRIPTION_LIMIT:
@@ -83,7 +83,7 @@ def put(json_request_body: dict, replica: str):
     return subscription_doc, requests.codes.created
 
 
-@security.assert_security(['hca', 'public'])
+@security.assert_security(['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)

--- a/environment
+++ b/environment
@@ -131,11 +131,11 @@ API_DOMAIN_NAME="dss.${DSS_DEPLOYMENT_STAGE}.ucsc-cgp-redwood.org"
 TOKENINFO_FUNC=dss.util.security.verify_jwt
 # TODO remove https://dev.data.humancellatlas.org/ from OIDC_AUDIENCE once seperate deployments are made
 
-OIDC_AUDIENCE=https://dss.dev.ucsc-cgp-redwood.org
-AUTH_URL=https://auth.ucsc.ucsc-cgp-redwood.org
+OIDC_AUDIENCE=https://dev.ucsc-cgp-redwood.org/
+AUTH_URL=https://dev-4lyab62k.auth0.com
 OPENID_PROVIDER=https://dev-4lyab62k.auth0.com/
-OIDC_EMAIL_CLAIM="${OIDC_AUDIENCE}/email"
-OIDC_GROUP_CLAIM="${OIDC_AUDIENCE}/group"
+OIDC_EMAIL_CLAIM="${OIDC_AUDIENCE}email"
+OIDC_GROUP_CLAIM="${OIDC_AUDIENCE}group"
 AUTH_BACKEND=Fusillade
 
 NOTIFY_URL=https://${API_DOMAIN_NAME}/internal/notify

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -106,7 +106,7 @@ def get_service_jwt(service_credentials, group: str = None, email=True, email_cl
     return signed_jwt
 
 
-def get_auth_header(real_header=True, authorized=True, group='hca', email=True, email_claim=False):
+def get_auth_header(real_header=True, authorized=True, group='dbio', email=True, email_claim=False):
     if authorized:
         credential_file = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
         with io.open(credential_file) as fh:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,7 +143,7 @@ class TestSecurity(unittest.TestCase):
         for token_info in invalid_token_info:
             with self.subTest(token_info):
                 with self.assertRaises(DSSForbiddenException):
-                    self.fus_handler.assert_authorized_group(['hca'], token_info)
+                    self.fus_handler.assert_authorized_group(['dbio'], token_info)
 
     @mock.patch('dss.Config._OIDC_AUDIENCE', new=["https://dev.data.humancellatlas.org/",
                                                   "https://data.humancellatlas.org/"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,12 +126,12 @@ class TestSecurity(unittest.TestCase):
                     security.assert_authorized_issuer(issuer)
 
     def test_authorizated_group(self):
-        valid_token_infos = [{os.environ['OIDC_GROUP_CLAIM']: 'hca'},
+        valid_token_infos = [{os.environ['OIDC_GROUP_CLAIM']: 'dbio'},
                              {os.environ['OIDC_GROUP_CLAIM']: 'public'}
                              ]
         for token_info in valid_token_infos:
             with self.subTest(token_info):
-                self.fus_handler.assert_authorized_group(['hca', 'public'], token_info)
+                self.fus_handler.assert_authorized_group(['dbio', 'public'], token_info)
 
     def test_not_authorizated_group(self):
         invalid_token_info = [{'sub': "travis-test@human-cell-atlas-travis-test.gmail.com"},


### PR DESCRIPTION
changes the required groups from `hca` to `dbio`
points the security audience to `https://dev.ucsc-cgp-redwood.org`
removes use of ucsc-fus as a proxy for OIDC
