### PR TITLE
DSS Auth: Require all security decorator parameters to be keyword args

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -49,7 +49,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups=['dbio'])
 def list_collections(per_page: int, start_at: int = 0):
     """
     Return a list of a user's collections.
@@ -87,7 +87,7 @@ def list_collections(per_page: int, start_at: int = 0):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups=['dbio'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)
@@ -97,7 +97,7 @@ def get(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups=['dbio'])
 def put(json_request_body: dict, replica: str, uuid: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = dict(json_request_body, owner=authenticated_user_email)
@@ -118,7 +118,7 @@ def put(json_request_body: dict, replica: str, uuid: str, version: str):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups=['dbio'])
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 
@@ -157,7 +157,7 @@ def _dedpuplicate_contents(contents: List) -> List:
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups=['dbio'])
 def delete(uuid: str, replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -188,7 +188,7 @@ def _verify_checkout(
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups=['dbio'])
 def put(uuid: str, json_request_body: dict, version: str):
     class CopyMode(Enum):
         NO_COPY = auto()

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -19,7 +19,7 @@ from dss.config import SUBSCRIPTION_LIMIT
 logger = logging.getLogger(__name__)
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 
@@ -45,7 +45,7 @@ def get(uuid: str, replica: str):
     return jsonify(source), requests.codes.okay
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     es_client = ElasticsearchClient.get()
@@ -66,7 +66,7 @@ def find(replica: str):
     return jsonify(full_response), requests.codes.okay
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     uuid = str(uuid4())
     es_query = json_request_body['es_query']
@@ -153,7 +153,7 @@ def put(json_request_body: dict, replica: str):
     return jsonify(dict(uuid=uuid)), requests.codes.created
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -17,7 +17,7 @@ from dss.subscriptions_v2 import (SubscriptionData,
                                   count_subscriptions_for_owner)
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)
@@ -28,7 +28,7 @@ def get(uuid: str, replica: str):
     return subscription, requests.codes.ok
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     subscriptions = get_subscriptions_for_owner(Replica[replica], owner)
@@ -39,7 +39,7 @@ def find(replica: str):
     return {'subscriptions': subscriptions}, requests.codes.ok
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     owner = security.get_token_email(request.token_info)
     if count_subscriptions_for_owner(Replica[replica], owner) > SUBSCRIPTION_LIMIT:
@@ -83,7 +83,7 @@ def put(json_request_body: dict, replica: str):
     return subscription_doc, requests.codes.created
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -17,7 +17,7 @@ class Auth0(Authorize):
                               'update': self._update,
                               'delete': self._delete}
 
-    def security_flow(self, *args, **kwargs):
+    def security_flow(self, **kwargs):
         """
         Dispatch pattern: the assert_security decorator will specify
         the type of operation (CRUD), which is passed through to the

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -24,15 +24,8 @@ class Auth0(Authorize):
         kwargs of this method, and used to call the correct method.
         """
         #  TODO add some type of jwt inspection
-
-        # Get name of method to use
-        if 'auth_method' in kwargs:
-            method = kwargs['auth_method']
-        elif len(args) > 0:
-            method = args[0]
-            kwargs['auth_method'] = method
-        else:
-            raise RuntimeError("Error: invalid arguments passed to Auth0 security_flow() method")
+        self.assert_required_parameters(kwargs, 'method')
+        method = kwargs['method']
 
         # Ensure method is valid
         if method is None or method not in self.valid_methods.keys():
@@ -40,9 +33,8 @@ class Auth0(Authorize):
             err += f'{", ".join(self.valid_methods)}'
             raise DSSException(500, err)
 
-        # Any further kwarg processing should happen
-        # from inside the method that needs that info,
-        # to limit specifications.
+        # Further kwarg processing should happen from
+        # inside the method that nees the info.
 
         # Dispatch to correct method
         executed_method = self.valid_methods[method]
@@ -51,14 +43,8 @@ class Auth0(Authorize):
     def _create(self, *args, **kwargs):
         """Auth checks for any 'create' API endpoint actions"""
         # Get name of allowed groups (either security_groups kwarg or second positional arg)
-        if 'security_groups' in kwargs:
-            groups = kwargs['security_groups']
-        elif len(args) > 1:
-            groups = args[1]
-            kwargs['security_groups'] = groups
-        else:
-            raise RuntimeError("Error: invalid arguments passed to Auth0 security_flow() method")
-
+        self.assert_required_parameters(kwargs, 'groups')
+        groups = kwargs['groups']
         self._assert_authorized_group(groups)
         return
 

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -34,7 +34,7 @@ class Auth0(Authorize):
             raise DSSException(500, err)
 
         # Further kwarg processing should happen from
-        # inside the method that nees the info.
+        # inside the method that needs the info.
 
         # Dispatch to correct method
         executed_method = self.valid_methods[method]
@@ -42,7 +42,6 @@ class Auth0(Authorize):
 
     def _create(self, **kwargs):
         """Auth checks for any 'create' API endpoint actions"""
-        # Get name of allowed groups (either security_groups kwarg or second positional arg)
         self.assert_required_parameters(kwargs, ['groups'])
         groups = kwargs['groups']
         self._assert_authorized_group(groups)

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -24,7 +24,7 @@ class Auth0(Authorize):
         kwargs of this method, and used to call the correct method.
         """
         #  TODO add some type of jwt inspection
-        self.assert_required_parameters(kwargs, 'method')
+        self.assert_required_parameters(kwargs, ['method'])
         method = kwargs['method']
 
         # Ensure method is valid

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -38,9 +38,9 @@ class Auth0(Authorize):
 
         # Dispatch to correct method
         executed_method = self.valid_methods[method]
-        executed_method(*args, **kwargs)
+        executed_method(**kwargs)
 
-    def _create(self, *args, **kwargs):
+    def _create(self, **kwargs):
         """Auth checks for any 'create' API endpoint actions"""
         # Get name of allowed groups (either security_groups kwarg or second positional arg)
         self.assert_required_parameters(kwargs, 'groups')
@@ -48,7 +48,7 @@ class Auth0(Authorize):
         self._assert_authorized_group(groups)
         return
 
-    def _read(self, *args, **kwargs):
+    def _read(self, **kwargs):
         # Data is public by default
         pass
 
@@ -60,10 +60,10 @@ class Auth0(Authorize):
         # both the decorator and the decorated function,
         # so that's how we can get requested UUID
 
-    def _update(self, *args, **kwargs):
+    def _update(self, **kwargs):
         # Requires checking ownership of UUID
         pass
 
-    def _delete(self, *args, **kwargs):
+    def _delete(self, **kwargs):
         # Requires checking ownership of UUID
         pass

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -43,7 +43,7 @@ class Auth0(Authorize):
     def _create(self, **kwargs):
         """Auth checks for any 'create' API endpoint actions"""
         # Get name of allowed groups (either security_groups kwarg or second positional arg)
-        self.assert_required_parameters(kwargs, 'groups')
+        self.assert_required_parameters(kwargs, ['groups'])
         groups = kwargs['groups']
         self._assert_authorized_group(groups)
         return

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -43,8 +43,7 @@ class Auth0(Authorize):
     def _create(self, **kwargs):
         """Auth checks for any 'create' API endpoint actions"""
         self.assert_required_parameters(kwargs, ['groups'])
-        groups = kwargs['groups']
-        self._assert_authorized_group(groups)
+        self._assert_authorized_group(kwargs['groups'])
         return
 
     def _read(self, **kwargs):

--- a/dss/util/auth/authorize.py
+++ b/dss/util/auth/authorize.py
@@ -30,7 +30,7 @@ class AuthorizeBase(metaclass=AuthRegistry):
     def __init__(self):
         pass
 
-    def security_flow(self, *args, **kwargs):
+    def security_flow(self, **kwargs):
         """
         This function maps out flow for a given security config
         """

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -15,10 +15,10 @@ class Fusillade(Authorize):
     This class defines the Fusillade security flow.
 
     security_flow method keyword arguments:
-    security_groups : list of allowed groups
+    groups : list of allowed groups
 
     Example:
-    @assert_security(security_groups = ['mygrp', 'myothrgrp'])
+    @assert_security(groups = ['dbio', 'myothrgrp'])
     def put(...)
     """
     def __init__(self):
@@ -32,8 +32,8 @@ class Fusillade(Authorize):
         a simpler check that the user's token group claim is in one of
         the allowed groups.
         """
-        self.assert_required_parameters(kwargs, 'security_groups')
-        groups = kwargs['security_groups']
+        self.assert_required_parameters(kwargs, 'groups')
+        groups = kwargs['groups']
         self._assert_authorized_group(groups)
         return
 

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -24,7 +24,7 @@ class Fusillade(Authorize):
     def __init__(self):
         self.session = requests.Session()
 
-    def security_flow(self, *args, **kwargs):
+    def security_flow(self, **kwargs):
         """
         This method maps out security flow for Auth with Fusillade.
         We are not using Fusillade 2.x /evaluate endpoint, which would

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -18,7 +18,7 @@ class Fusillade(Authorize):
     groups : list of allowed groups
 
     Example:
-    @assert_security(groups = ['dbio', 'myothrgrp'])
+    @assert_security(groups=['dbio', 'myothrgrp'])
     def put(...)
     """
     def __init__(self):

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -14,15 +14,11 @@ class Fusillade(Authorize):
     """
     This class defines the Fusillade security flow.
 
-    Main entry point is security_flow.
-    Arrgs and kwargs are passed in from the security decorator
-    @assert_security.
-
-    Keyword arguments:
-    - security_groups: list of allowed groups
+    security_flow method keyword arguments:
+    security_groups : list of allowed groups
 
     Example:
-    @assert_security(['mygrp', 'myothergrp'])
+    @assert_security(security_groups = ['mygrp', 'myothrgrp'])
     def put(...)
     """
     def __init__(self):
@@ -31,25 +27,17 @@ class Fusillade(Authorize):
     def security_flow(self, *args, **kwargs):
         """
         This method maps out security flow for Auth with Fusillade.
-
-        The current implementation of Fusillade (2.x) uses three pieces of information
-        to evaluate authorization: principals, actions, and resources.
-
-        However, we have overridden this with a simpler authentication-based
-        authorization layer that just checks for membership in a group.
+        We are not using Fusillade 2.x /evaluate endpoint, which would
+        require principals actions, and resources. Instead, we go for
+        a simpler check that the user's token group claim is in one of
+        the allowed groups.
         """
-        if 'security_groups' in kwargs:
-            groups = kwargs['security_groups']
-        elif len(args) > 0:
-            groups = args[0]
-        else:
-            raise RuntimeError("Error: invalid arguments passed to Fusillade security_flow() method")
+        self.assert_required_parameters(kwargs, 'security_groups')
+        groups = kwargs['security_groups']
         self._assert_authorized_group(groups)
         return
 
-        # If we were using Fusillade's evaluate endpoint,
-        # this is where we would extract relevant information
-        # from the security decorator.
+        # If using Fusillade's /evaluate endpoint:
         self.assert_required_parameters(kwargs, ['principal', 'actions', 'resource'])
         self.assert_authorized(kwargs['principal'], kwargs['actions'], kwargs['resources'])
 

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -33,8 +33,7 @@ class Fusillade(Authorize):
         the allowed groups.
         """
         self.assert_required_parameters(kwargs, ['groups'])
-        groups = kwargs['groups']
-        self._assert_authorized_group(groups)
+        self._assert_authorized_group(kwargs['groups'])
         return
 
         # If using Fusillade's /evaluate endpoint:

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -32,7 +32,7 @@ class Fusillade(Authorize):
         a simpler check that the user's token group claim is in one of
         the allowed groups.
         """
-        self.assert_required_parameters(kwargs, 'groups')
+        self.assert_required_parameters(kwargs, ['groups'])
         groups = kwargs['groups']
         self._assert_authorized_group(groups)
         return

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -141,7 +141,7 @@ def assert_security(**decorator_kwargs):
             # Pass all args/kwargs to AuthWrapper
             authz_handler = AuthWrapper()
             authz_handler.security_flow(**decorator_kwargs)
-            return func(**kwargs)
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -119,7 +119,7 @@ def assert_authorized_email(emails: typing.List[str], token: dict) -> None:
     raise DSSForbiddenException()
 
 
-def assert_security(*decorator_args, **decorator_kwargs):
+def assert_security(**decorator_kwargs):
     # Note: we use 3 total layers of function wrappers here,
     # not the usual 2 when wrapping functions, because the
     # wrappers we are defining take *args and **kwargs.
@@ -140,8 +140,8 @@ def assert_security(*decorator_args, **decorator_kwargs):
                     pass
             # Pass all args/kwargs to AuthWrapper
             authz_handler = AuthWrapper()
-            authz_handler.security_flow(*decorator_args, **decorator_kwargs)
-            return func(*args, **kwargs)
+            authz_handler.security_flow(**decorator_kwargs)
+            return func(**kwargs)
 
         return wrapper
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -99,13 +99,13 @@ class TestFusilladeAuth(unittest.TestCase):
             # Test that security flow succeeds for each auth backend
             with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
                 auth = AuthWrapper()
-                auth.security_flow(['dbio'])
+                auth.security_flow(groups=['dbio'])
             with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
                 auth = AuthWrapper()
-                auth.security_flow('create', ['dbio'])
-                auth.security_flow('read')
-                auth.security_flow('update')
-                auth.security_flow('delete')
+                auth.security_flow(method='create', groups=['dbio'])
+                auth.security_flow(method='read')
+                auth.security_flow(method='update')
+                auth.security_flow(method='delete')
 
     def test_unauthorized_security_flow(self):
         invalid_token = {}
@@ -116,10 +116,10 @@ class TestFusilladeAuth(unittest.TestCase):
                 # Check failure due to empty token
                 with self.assertRaises(DSSForbiddenException):
                     auth = AuthWrapper()
-                    auth.security_flow(['dbio'])
+                    auth.security_flow(groups=['dbio'])
 
                 # Check failure due to invalid method signature
-                with self.assertRaises(RuntimeError):
+                with self.assertRaises(DSSException):
                     auth = AuthWrapper()
                     auth.security_flow()
 


### PR DESCRIPTION
This modifies the prior pull request #126 so that none of the security decorators accept positional arguments. This makes the code inside the authorization classes cleaner, and makes it more clear where and how to check for required parameters.

This also updates tests so that they will pass using the new decorators.