### PR TITLE
DSS Auth: Update API security decorators to use kwargs not args

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -49,7 +49,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(groups = ['dbio'])
+@security.assert_security(groups=['dbio'])
 def list_collections(per_page: int, start_at: int = 0):
     """
     Return a list of a user's collections.
@@ -87,7 +87,7 @@ def list_collections(per_page: int, start_at: int = 0):
 
 
 @dss_handler
-@security.assert_security(groups = ['dbio'])
+@security.assert_security(groups=['dbio'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)
@@ -97,7 +97,7 @@ def get(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(groups = ['dbio'])
+@security.assert_security(groups=['dbio'])
 def put(json_request_body: dict, replica: str, uuid: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = dict(json_request_body, owner=authenticated_user_email)
@@ -118,7 +118,7 @@ def put(json_request_body: dict, replica: str, uuid: str, version: str):
 
 
 @dss_handler
-@security.assert_security(groups = ['dbio'])
+@security.assert_security(groups=['dbio'])
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 
@@ -157,7 +157,7 @@ def _dedpuplicate_contents(contents: List) -> List:
 
 
 @dss_handler
-@security.assert_security(groups = ['dbio'])
+@security.assert_security(groups=['dbio'])
 def delete(uuid: str, replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -49,7 +49,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups = ['dbio'])
 def list_collections(per_page: int, start_at: int = 0):
     """
     Return a list of a user's collections.
@@ -87,7 +87,7 @@ def list_collections(per_page: int, start_at: int = 0):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups = ['dbio'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)
@@ -97,7 +97,7 @@ def get(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups = ['dbio'])
 def put(json_request_body: dict, replica: str, uuid: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = dict(json_request_body, owner=authenticated_user_email)
@@ -118,7 +118,7 @@ def put(json_request_body: dict, replica: str, uuid: str, version: str):
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups = ['dbio'])
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 
@@ -157,7 +157,7 @@ def _dedpuplicate_contents(contents: List) -> List:
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups = ['dbio'])
 def delete(uuid: str, replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -188,7 +188,7 @@ def _verify_checkout(
 
 
 @dss_handler
-@security.assert_security(['dbio'])
+@security.assert_security(groups = ['dbio'])
 def put(uuid: str, json_request_body: dict, version: str):
     class CopyMode(Enum):
         NO_COPY = auto()

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -188,7 +188,7 @@ def _verify_checkout(
 
 
 @dss_handler
-@security.assert_security(groups = ['dbio'])
+@security.assert_security(groups=['dbio'])
 def put(uuid: str, json_request_body: dict, version: str):
     class CopyMode(Enum):
         NO_COPY = auto()

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -19,7 +19,7 @@ from dss.config import SUBSCRIPTION_LIMIT
 logger = logging.getLogger(__name__)
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 
@@ -45,7 +45,7 @@ def get(uuid: str, replica: str):
     return jsonify(source), requests.codes.okay
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     es_client = ElasticsearchClient.get()
@@ -66,7 +66,7 @@ def find(replica: str):
     return jsonify(full_response), requests.codes.okay
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     uuid = str(uuid4())
     es_query = json_request_body['es_query']
@@ -153,7 +153,7 @@ def put(json_request_body: dict, replica: str):
     return jsonify(dict(uuid=uuid)), requests.codes.created
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -19,7 +19,7 @@ from dss.config import SUBSCRIPTION_LIMIT
 logger = logging.getLogger(__name__)
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 
@@ -45,7 +45,7 @@ def get(uuid: str, replica: str):
     return jsonify(source), requests.codes.okay
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     es_client = ElasticsearchClient.get()
@@ -66,7 +66,7 @@ def find(replica: str):
     return jsonify(full_response), requests.codes.okay
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     uuid = str(uuid4())
     es_query = json_request_body['es_query']
@@ -153,7 +153,7 @@ def put(json_request_body: dict, replica: str):
     return jsonify(dict(uuid=uuid)), requests.codes.created
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -17,7 +17,7 @@ from dss.subscriptions_v2 import (SubscriptionData,
                                   count_subscriptions_for_owner)
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)
@@ -28,7 +28,7 @@ def get(uuid: str, replica: str):
     return subscription, requests.codes.ok
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     subscriptions = get_subscriptions_for_owner(Replica[replica], owner)
@@ -39,7 +39,7 @@ def find(replica: str):
     return {'subscriptions': subscriptions}, requests.codes.ok
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     owner = security.get_token_email(request.token_info)
     if count_subscriptions_for_owner(Replica[replica], owner) > SUBSCRIPTION_LIMIT:
@@ -83,7 +83,7 @@ def put(json_request_body: dict, replica: str):
     return subscription_doc, requests.codes.created
 
 
-@security.assert_security(['dbio', 'public'])
+@security.assert_security(groups = ['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -17,7 +17,7 @@ from dss.subscriptions_v2 import (SubscriptionData,
                                   count_subscriptions_for_owner)
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)
@@ -28,7 +28,7 @@ def get(uuid: str, replica: str):
     return subscription, requests.codes.ok
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     subscriptions = get_subscriptions_for_owner(Replica[replica], owner)
@@ -39,7 +39,7 @@ def find(replica: str):
     return {'subscriptions': subscriptions}, requests.codes.ok
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     owner = security.get_token_email(request.token_info)
     if count_subscriptions_for_owner(Replica[replica], owner) > SUBSCRIPTION_LIMIT:
@@ -83,7 +83,7 @@ def put(json_request_body: dict, replica: str):
     return subscription_doc, requests.codes.created
 
 
-@security.assert_security(groups = ['dbio', 'public'])
+@security.assert_security(groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -24,7 +24,7 @@ class Auth0(Authorize):
         kwargs of this method, and used to call the correct method.
         """
         #  TODO add some type of jwt inspection
-        self.assert_required_parameters(kwargs, 'method')
+        self.assert_required_parameters(kwargs, ['method'])
         method = kwargs['method']
 
         # Ensure method is valid

--- a/dss/util/auth/fusillade.py
+++ b/dss/util/auth/fusillade.py
@@ -18,7 +18,7 @@ class Fusillade(Authorize):
     groups : list of allowed groups
 
     Example:
-    @assert_security(groups = ['dbio', 'myothrgrp'])
+    @assert_security(groups=['dbio', 'myothrgrp'])
     def put(...)
     """
     def __init__(self):


### PR DESCRIPTION
PR #128 changes the security decorators to not use positional arguments, only keyword arguments. This PR updates all the security decorators on existing endpoints to use kwargs not args.
