### PR TITLE
[Auth0 CRUD Part 1] Implement Auth0 CRUD endpoints

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -381,12 +381,8 @@ class Config:
 
     @staticmethod
     def get_notification_email() -> str:
-        envvar = "DSS_NOTIFICATION_SENDER"
-        if envvar not in os.environ:
-            raise Exception(
-                "Please set the {} environment variable".format(envvar))
-        Config._NOTIFICATION_SENDER_EMAIL = os.environ[envvar]
-
+        val = Config._get_required_envvar("DSS_NOTIFICATION_SENDER")
+        Config._NOTIFICATION_SENDER_EMAIL = val
         return Config._NOTIFICATION_SENDER_EMAIL
 
     @staticmethod

--- a/dss/config.py
+++ b/dss/config.py
@@ -391,11 +391,9 @@ class Config:
 
     @staticmethod
     def get_admin_user_emails() -> typing.List[str]:
-        envvar = "ADMIN_USER_EMAILS"
-        if envvar not in os.environ:
-            raise Exception(
-                "Please set the {} environment variable".format(envvar))
-        Config._ADMIN_USER_EMAILS_LIST = os.environ[envvar].split(",")
+        val_str = Config._get_required_envvar("ADMIN_USER_EMAILS")
+        val_list = [j.strip() for j in val_str.split(",")]
+        Config._ADMIN_USER_EMAILS_LIST = val_list
         return Config._ADMIN_USER_EMAILS_LIST
 
     @staticmethod

--- a/dss/config.py
+++ b/dss/config.py
@@ -117,6 +117,7 @@ class Config:
     _NOTIFICATION_SENDER_EMAIL: typing.Optional[str] = None
     _ADMIN_USER_EMAILS_LIST: typing.Optional[typing.List[str]] = None
     _TRUSTED_GOOGLE_PROJECTS: typing.Optional[typing.List[str]] = None
+    _OIDC_AUTH0_TOKEN_CLAIM: typing.Optional[str] = None
     _OIDC_AUDIENCE: typing.Optional[typing.List[str]] = None
     _AUTH_URL: typing.Optional[str] = None
     _AUTH_BACKEND: typing.Optional[str] = None
@@ -391,6 +392,19 @@ class Config:
         val_list = [j.strip() for j in val_str.split(",")]
         Config._ADMIN_USER_EMAILS_LIST = val_list
         return Config._ADMIN_USER_EMAILS_LIST
+
+    @staticmethod
+    def get_auth0_claim():
+        backend = Config.get_auth_backend()
+        if backend == "auth0":
+            if Config._OIDC_AUTH0_TOKEN_CLAIM is None:
+                val = Config._get_required_envvar("OIDC_AUTH0_TOKEN_CLAIM")
+                Config._OIDC_AUTH0_TOKEN_CLAIM = val
+        else:
+            raise Exception("auth backend misconfigured: Config.get_auth0_claim() expected "
+                            f"\"auth0\" but got \"{backend}\"")
+
+        return Config._OIDC_AUTH0_TOKEN_CLAIM
 
     @staticmethod
     def debug_level() -> int:

--- a/dss/config.py
+++ b/dss/config.py
@@ -115,6 +115,7 @@ class Config:
     _ALLOWED_GOOGLE_PROJECTS: typing.Optional[str] = None
     _CURRENT_CONFIG: BucketConfig = BucketConfig.ILLEGAL
     _NOTIFICATION_SENDER_EMAIL: typing.Optional[str] = None
+    _ADMIN_USER_EMAILS_LIST: typing.Optional[typing.List[str]] = None
     _TRUSTED_GOOGLE_PROJECTS: typing.Optional[typing.List[str]] = None
     _OIDC_AUDIENCE: typing.Optional[typing.List[str]] = None
     _AUTH_URL: typing.Optional[str] = None
@@ -387,6 +388,15 @@ class Config:
         Config._NOTIFICATION_SENDER_EMAIL = os.environ[envvar]
 
         return Config._NOTIFICATION_SENDER_EMAIL
+
+    @staticmethod
+    def get_admin_user_emails() -> typing.List[str]:
+        envvar = "ADMIN_USER_EMAILS"
+        if envvar not in os.environ:
+            raise Exception(
+                "Please set the {} environment variable".format(envvar))
+        Config._ADMIN_USER_EMAILS_LIST = os.environ[envvar].split(",")
+        return Config._ADMIN_USER_EMAILS_LIST
 
     @staticmethod
     def debug_level() -> int:

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -4,11 +4,27 @@ from dss.error import DSSForbiddenException, DSSException
 from .authorize import Authorize
 
 
-class Auth0(Authorize):
+class FlacMixin(Authorize):
+    def _assert_authorized_flac(self, **kwargs):
+        uuid = kwargs['uuid']
+        method = kwargs['method']
+        email = self.token_email
+        group = self.token_group
+        # Do FLAC lookup here
+        return
+
+
+class Auth0(FlacMixin):
     """
     Implements the Auth0 security flow, which implements different
     authorization checks based on whether operations are
     create/read/update/delete operations.
+
+    Decorator examples:
+    @security.assert_authorize(method='create', groups=['dbio', 'grp'])
+    @security.assert_authorize(method='read')
+    @security.assert_authorize(method='update', groups=['dbio', 'grp'])
+    @security.assert_authorize(method='delete')
     """
     def __init__(self):
         self.session = requests.Session()
@@ -41,27 +57,39 @@ class Auth0(Authorize):
         executed_method(**kwargs)
 
     def _create(self, **kwargs):
-        """Auth checks for any 'create' API endpoint actions"""
+        """Auth checks for 'create' API actions"""
+        # Only check that a user is a member of a list of allowed organizations
         self.assert_required_parameters(kwargs, ['groups'])
         self._assert_authorized_group(kwargs['groups'])
         return
 
     def _read(self, **kwargs):
-        # Data is public by default
-        pass
-
-        # Eventually we will do a FLAC lookup first.
-        # If FLAC lookup doesn't raise exceptions,
-        # the requested read access will be granted.
-
-        # args/kwargs should include args/kwargs from
-        # both the decorator and the decorated function,
-        # so that's how we can get requested UUID
+        """Auth checks for 'read' API actions"""
+        # Data is public if there is no FLAC table entry.
+        self._assert_authorized_flac(**kwargs)
+        return
 
     def _update(self, **kwargs):
-        # Requires checking ownership of UUID
+        """Auth checks for 'update' API actions"""
+        try:
+            # Admins are always allowed to update
+            self._assert_admin(**kwargs)
+            return
+        except DSSException:
+            # Update requires read and create access
+            # Assert user has read access
+            read_kwargs = kwargs.copy()
+            read_kwargs['method'] = 'read'
+            self._read(**read_kwargs)
+
+            # Assert user has create access
+            create_kwargs = kwargs.copy()
+            create_kwargs['method'] = 'create'
+            self.assert_required_parameters(create_kwargs, ['groups'])
+            self._create(**create_kwargs)
         pass
 
     def _delete(self, **kwargs):
-        # Requires checking ownership of UUID
-        pass
+        """Auth checks for 'delete' API actions"""
+        # Only admins allowed
+        self._assert_admin(**kwargs)

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -52,6 +52,14 @@ class Auth0AuthZGroupsMixin(Authorize):
         groups = self.token[auth0authz_claim][auth0authz_groups_claim]
         return groups
 
+    def assert_auth0authz_groups_intersects(self, groups):
+        """
+        Assert that the intersection of Auth0 AuthZ groups and user-provided groups
+        has cardinality greater than zero (intersection has at least 1 member).
+        """
+        cardinality = len(set(self.auth0authz_groups).intersection(set(groups)))
+        return cardinality > 0
+
 
 class Auth0(FlacMixin, Auth0AuthZGroupsMixin):
     """

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -1,5 +1,6 @@
 import requests
 
+from dss import Config
 from dss.error import DSSForbiddenException, DSSException
 from .authorize import Authorize
 
@@ -33,7 +34,8 @@ class Auth0AuthZGroupsMixin(Authorize):
     but here we just use groups.)
     """
     def _get_auth0authz_claim(self):
-        return "https://dev.ucsc-cgp-redwood.org/auth0"
+        oidc_audience = Config.get_audience()[0]
+        return f"{oidc_audience}auth0"
 
     def _get_auth0authz_group_claim(self):
         return "groups"
@@ -120,7 +122,7 @@ class Auth0(FlacMixin, Auth0AuthZGroupsMixin):
         """Auth checks for 'update' API actions"""
         try:
             # Admins are always allowed to update
-            self._assert_admin(**kwargs)
+            self._assert_admin()
             return
         except DSSException:
             # Update requires read and create access
@@ -139,4 +141,4 @@ class Auth0(FlacMixin, Auth0AuthZGroupsMixin):
     def _delete(self, **kwargs):
         """Auth checks for 'delete' API actions"""
         # Only admins allowed
-        self._assert_admin(**kwargs)
+        self._assert_admin()

--- a/dss/util/auth/authorize.py
+++ b/dss/util/auth/authorize.py
@@ -79,6 +79,7 @@ class TokenGroupMixin(TokenMixin):
     def token_group(self):
         """Property for the user's JWT group claim"""
         group_claim = Config.get_OIDC_group_claim()
+        self.assert_required_parameters(self.token, [group_claim])
         return self.token[group_claim]
 
     def _assert_authorized_group(self, groups):
@@ -98,6 +99,7 @@ class TokenEmailMixin(TokenMixin):
     def token_email(self):
         """Property for the user's JWT email claim"""
         email_claim = Config.get_OIDC_email_claim()
+        self.assert_required_parameters(self.token, [email_claim])
         return self.token[email_claim]
 
     def _assert_authorized_email(self, emails):

--- a/dss/util/auth/authorize.py
+++ b/dss/util/auth/authorize.py
@@ -107,5 +107,20 @@ class TokenEmailMixin(TokenMixin):
         return
 
 
-class Authorize(TokenGroupMixin, TokenEmailMixin):
+class AdminStatusMixin(TokenGroupMixin, TokenEmailMixin):
+    @property
+    def admin_emails(self):
+        """Property for the list of admin user emails"""
+        admin_emails = ",".split(os.environ['ADMIN_USER_EMAILS'])
+        return admin_emails
+
+    def _assert_admin(self):
+        """Boolean property: is token_email an admin email"""
+        if self.token_email:
+            if self.token_email in admin_emails:
+                return True
+        return False
+
+
+class Authorize(AdminStatusMixin):
     pass

--- a/dss/util/auth/authorize.py
+++ b/dss/util/auth/authorize.py
@@ -111,13 +111,13 @@ class AdminStatusMixin(TokenGroupMixin, TokenEmailMixin):
     @property
     def admin_emails(self):
         """Property for the list of admin user emails"""
-        admin_emails = ",".split(os.environ['ADMIN_USER_EMAILS'])
+        admin_emails = Config.get_admin_user_emails()
         return admin_emails
 
     def _assert_admin(self):
         """Boolean property: is token_email an admin email"""
         if self.token_email:
-            if self.token_email in admin_emails:
+            if self.token_email in self.admin_emails:
                 return True
         return False
 

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -105,17 +105,21 @@ def assert_authorized_issuer(token: typing.Mapping[str, typing.Any]) -> None:
 
 def assert_authorized_group(groups: typing.List[str], token: dict) -> None:
     """Assert that a JWT token contains the given group under the group claim key"""
-    if token.get(Config.get_OIDC_group_claim()) in groups:
+    group_claim = Config.get_OIDC_group_claim()
+    group = token.get(group_claim)
+    if group in groups:
         return
-    logger.info(f"User not in any authorized groups: {groups}, {token}")
+    logger.info(f"User is not in authorized groups: user's group is {group}, authorized groups are {groups}")
     raise DSSForbiddenException()
 
 
 def assert_authorized_email(emails: typing.List[str], token: dict) -> None:
     """Assert that a JWT token contains the given email under the email claim key"""
-    if token.get(Config.get_OIDC_email_claim()) in emails:
+    email_claim = Config.get_OIDC_email_claim()
+    email = token.get(email_claim)
+    if email in emails:
         return
-    logger.info(f"User not in authorized emails: {emails}, {token}")
+    logger.info(f"User is not authorized: user's email is {email}, authorized emails are {emails}")
     raise DSSForbiddenException()
 
 

--- a/environment
+++ b/environment
@@ -137,6 +137,7 @@ AUTH_URL=https://dev-4lyab62k.auth0.com
 OPENID_PROVIDER=https://dev-4lyab62k.auth0.com/
 OIDC_EMAIL_CLAIM="${OIDC_AUDIENCE}email"
 OIDC_GROUP_CLAIM="${OIDC_AUDIENCE}group"
+OIDC_AUTH0_TOKEN_CLAIM="${OIDC_AUDIENCE}auth0"
 AUTH_BACKEND=Fusillade
 
 NOTIFY_URL=https://${API_DOMAIN_NAME}/internal/notify

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,15 +11,52 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss import DSSException, DSSForbiddenException, Config
 from dss.util.auth import AuthWrapper
-from dss.util.auth.authorize import (AuthorizeBase, TokenMixin, TokenGroupMixin, TokenEmailMixin)
+from dss.util.auth.authorize import \
+    (AuthorizeBase, TokenMixin, TokenGroupMixin, TokenEmailMixin, AdminStatusMixin, always_allow_admins)
+from dss.util.auth.auth0 import (FlacMixin, Auth0AuthZGroupsMixin)
 from tests.infra import testmode
+from tests import get_service_jwt, UNAUTHORIZED_GCP_CREDENTIALS
 
 
-def get_group_claim_token(grp):
-    return {os.environ['OIDC_GROUP_CLAIM']: grp}
+def get_token_issuer_claim(iss: str) -> dict:
+    token = {}
+    token['iss'] = iss
+    return token
 
-def get_email_claim_token(eml):
-    return {os.environ['OIDC_EMAIL_CLAIM']: eml}
+
+def get_token_email_claim(eml: str, iss: str = '') -> dict:
+    token = get_token_issuer_claim(iss)
+    token[Config.get_OIDC_email_claim()] = eml
+    return token
+
+
+def get_token_group_claim(grp: str, eml: str = '', iss: str = '') -> dict:
+    token = get_token_email_claim(eml, iss)
+    token[Config.get_OIDC_group_claim()] = grp
+    return token
+
+
+def get_token_auth0_claim(grp: str, auth0authzgrp: str, eml: str = '', iss: str = '') -> dict:
+    """
+    Add a claim at {OIDC_AUDIENCE}/auth0 to mimick what the Auth0 AuthZ extension adds.
+    User must specify both token group (grp) and Auth0 AuthZ group (auth0authzgrp).
+    """
+    token = get_token_group_claim(grp, eml, iss)
+    auth0claim = Auth0AuthZGroupsMixin.get_auth0authz_claim()
+    token[auth0claim] = {
+        "groups": [auth0authzgrp],
+        "roles": [],
+        "permissions": []
+    }
+    return token
+
+
+def get_token_admin_claim() -> dict:
+    token = get_token_issuer_claim('')
+    admin_user_emails = Config.get_admin_user_emails()
+    token[Config.get_OIDC_email_claim()] = admin_user_emails[0]
+    return token
+
 
 class TestAuthBase(unittest.TestCase):
     """
@@ -29,13 +66,13 @@ class TestAuthBase(unittest.TestCase):
     def setUpClass(cls):
         dss.Config.set_config(dss.BucketConfig.TEST)
 
-    def test_auth_security_flow(self):
+    def test_base_auth_security_flow(self):
         # Virtual methods gonna virtual
         a = AuthorizeBase()
         with self.assertRaises(NotImplementedError):
             a.security_flow()
 
-    def test_assert_required_parameters(self):
+    def test_base_assert_required_parameters(self):
         params = {
             'foo': 'bar',
             'baz': 'wuz'
@@ -48,80 +85,151 @@ class TestAuthMixins(unittest.TestCase):
     """
     Test the various mixins defined for Authorize classes
     """
-
     @classmethod
     def setUpClass(cls):
         dss.Config.set_config(dss.BucketConfig.TEST)
 
     def test_token_mixin(self):
-        # Check that when you set the token property on
-        # a TokenMixin instance, you get the token property
         tm = TokenMixin()
-        valid_token = get_group_claim_token('dbio')
-        invalid_token = get_group_claim_token('boo-this-is-an-invalid-token-group')
+        valid_token = get_token_issuer_claim(Config.get_openid_provider())
+        invalid_token = get_token_issuer_claim("invalid-issuer-auth_dss_test-auth_test-token-mixin")
         with mock.patch('dss.util.auth.authorize.TokenMixin.token', valid_token):
             self.assertEquals(tm.token, valid_token)
-            self.assertNotEquals(tm.token, invalid_token)
+            tm._assert_authorized_issuer()
+        with mock.patch('dss.util.auth.authorize.TokenMixin.token', invalid_token):
+            self.assertEquals(tm.token, invalid_token)
+            with self.assertRaises(DSSException):
+                tm._assert_authorized_issuer()
 
-    def test_group_token_mixin(self):
+    def test_token_group_mixin(self):
         tgm = TokenGroupMixin()
-        grp = 'dbio'
-        valid_token = get_group_claim_token(grp)
-        invalid_token = get_group_claim_token('boo-this-is-an-invalid-token-group')
+        valid_group = 'dbio'
+        valid_token = get_token_group_claim(valid_group)
+        invalid_token = get_token_group_claim("invalid-group_dss_test-auth_test-token-group-mixin")
         with mock.patch('dss.util.auth.authorize.TokenGroupMixin.token', valid_token):
-            tgm._assert_authorized_group([grp])
+            tgm._assert_authorized_group([valid_group])
         with mock.patch('dss.util.auth.authorize.TokenGroupMixin.token', invalid_token):
             with self.assertRaises(DSSException):
-                tgm._assert_authorized_group([grp])
+                tgm._assert_authorized_group([valid_group])
 
-    def test_email_token_mixin(self):
+    def test_token_email_mixin(self):
         tem = TokenEmailMixin()
-        eml = 'valid-email@dss-testauth-testemailtokenmixin.ucsc.edu'
-        valid_token = get_email_claim_token(eml)
-        invalid_token = get_email_claim_token(f'not-a-valid-email')
-        # Check valid and invalid tokens
+        valid_email = 'valid-email@dss_test-auth_test-token-email-mixin'
+        invalid_email = 'invalid-email@dss_test-auth_test-token-email-mixin'
+        valid_token = get_token_email_claim(valid_email)
+        invalid_token = get_token_email_claim(invalid_email)
         with mock.patch('dss.util.auth.authorize.TokenEmailMixin.token', valid_token):
-            tem._assert_authorized_email([eml])
+            tem._assert_authorized_email([valid_email])
         with mock.patch('dss.util.auth.authorize.TokenEmailMixin.token', invalid_token):
             with self.assertRaises(DSSException):
-                tem._assert_authorized_email([eml])
+                tem._assert_authorized_email([valid_email])
+
+    def test_admin_status_mixin(self):
+        asm = AdminStatusMixin()
+        admin_email = asm.admin_emails[0]
+        admin_token = get_token_email_claim(admin_email)
+        notadmin_token = get_token_email_claim('not-an-admin@dss_test-auth_test-admin-mixin')
+        with mock.patch('dss.util.auth.authorize.AdminStatusMixin.token', admin_token):
+            self.assertTrue(asm._is_admin())
+        with mock.patch('dss.util.auth.authorize.AdminStatusMixin.token', notadmin_token):
+            self.assertFalse(asm._is_admin())
+
+    def test_flac_mixin(self):
+        FlacMixin()
+
+    def test_auth0authz_mixin(self):
+        # Test class method to return the Auth0 claim
+        ok_claim = f"{Config.get_audience()[0]}auth0"
+        self.assertTrue(Auth0AuthZGroupsMixin.get_auth0authz_claim(), ok_claim)
+        # Create a token with the correct Auth0 claim
+        a0az = Auth0AuthZGroupsMixin()
+        valid_group = 'dbio'
+        valid_auth0authz_group = 'foobar'
+        invalid_auth0authz_group = 'not-foobar'
+        valid_token = get_token_auth0_claim(valid_group, valid_auth0authz_group)
+        with mock.patch('dss.util.auth.auth0.Auth0AuthZGroupsMixin.token', valid_token):
+            # Test access to A0AZ groups attribute
+            self.assertEqual(a0az.auth0authz_groups, [valid_auth0authz_group])
+            # Test ability to determine if A0AZ groups intersect a provided list
+            all_groups = [valid_auth0authz_group, invalid_auth0authz_group]
+            self.assertTrue(a0az.assert_auth0authz_groups_intersects(all_groups))
 
 
 class TestFusilladeAuth(unittest.TestCase):
     """
     Test security flow for Fusillade authentication and authorization layer.
     """
-
     def test_authorized_security_flow(self):
-        valid_token = get_group_claim_token('dbio')
-        with mock.patch('dss.util.auth.authorize.Authorize.token', valid_token):
+        valid_grp = 'dbio'
+        valid_token = get_token_group_claim(valid_grp)
+        self._test_security_flow(valid_token, valid_grp)
 
+    def test_unauthorized_security_flow(self):
+        valid_grp = 'dbio'
+        invalid_grp = 'not-a-valid-grp_dss_test-auth_test-fusillade'
+        invalid_token = get_token_group_claim(invalid_grp)
+        with self.assertRaises(DSSException):
+            self._test_security_flow(invalid_token, valid_grp)
+
+    def _test_security_flow(self, token: dict, allowed_grp: str):
+        with mock.patch('dss.util.auth.authorize.Authorize.token', token):
             # Test that security flow succeeds for each auth backend
             with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
                 auth = AuthWrapper()
-                auth.security_flow(groups=['dbio'])
-            with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
-                auth = AuthWrapper()
-                auth.security_flow(method='create', groups=['dbio'])
-                auth.security_flow(method='read')
-                auth.security_flow(method='update')
-                auth.security_flow(method='delete')
+                auth.security_flow(groups=[allowed_grp])  # type: ignore
+
+
+class TestAuth0Auth(unittest.TestCase):
+    """
+    Test security flow for Auth0 authentication and authorization layer.
+    """
+    def test_authorized_security_flow(self):
+        """
+        Create a token with a valid group claim, and run through the normal security flow to check for
+        a valid group claim.
+        """
+        valid_grp = 'dbio'
+        valid_token = get_token_group_claim(valid_grp)
+        self._test_security_flow(valid_token, valid_grp)
 
     def test_unauthorized_security_flow(self):
-        invalid_token = {}
-        with mock.patch('dss.util.auth.authorize.Authorize.token', invalid_token):
+        valid_grp = 'dbio'
+        invalid_grp = 'not-a-valid-group_dss_test-auth_test-auth0'
+        invalid_token = get_token_group_claim(invalid_grp)
+        with self.assertRaises(DSSException):
+            self._test_security_flow(invalid_token, valid_grp)
 
-            # Test that security flow fails for each auth backend
-            with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
-                # Check failure due to empty token
-                with self.assertRaises(DSSForbiddenException):
-                    auth = AuthWrapper()
-                    auth.security_flow(groups=['dbio'])
+    def test_admin_security_flow(self):
+        """
+        Create a token for an admin user, and run through the security flow to verify admins are allowed
+        to do all actions.
+        """
+        admin_token = get_token_admin_claim()
+        self._test_security_flow(admin_token, '', admin=True)
+        self._test_security_flow(admin_token, 'dbio', admin=True)
+        self._test_security_flow(admin_token, 'any-group-should-work', admin=True)
 
-                # Check failure due to invalid method signature
-                with self.assertRaises(DSSException):
-                    auth = AuthWrapper()
-                    auth.security_flow()
+    def _test_security_flow(self, token, allowed_grp, admin=False):
+        """
+        Private method: given a token and an allowed group, use the token to mock the Authorize class,
+        then test the security flow.
+
+        :param token: the token to use to mock Authorize.token
+        :param allowed_grp: use this group as the allowed group during the security flow
+        :param bool admin: is this user an admin? or will admin endpoints raise exceptions?
+        """
+        with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
+            with mock.patch('dss.util.auth.authorize.Authorize.token', token):
+                auth = AuthWrapper()
+                auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore
+                auth.security_flow(method='read')  # type: ignore
+                auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
+                if admin:
+                    auth.security_flow(method='delete')  # type: ignore
+                else:
+                    with self.assertRaises(DSSForbiddenException):
+                        auth.security_flow(method='delete')  # type: ignore
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Includes stub methods for FLAC table lookups. Implements logic described in #119.

Still requires work to implement FLAC table lookup mechanism.

Closes #119 (implement crud endpoints for Auth0) and closes #91 (datastore integration with Auth0)

Part 1: #130 (adds mixins for FLAC and Auth0AuthZ extensions, adds parameter checks)

Part 2: #135 (handles case of admin action)

Part 3: #136 (expands and updates tests, updates and fixes auth API)