### PR TITLE
DSS Wrappers: DynamoDB update

### DIFF
--- a/dss/collections/owner_lookup.py
+++ b/dss/collections/owner_lookup.py
@@ -19,6 +19,7 @@ def put_collection(owner: str, collection_fqid: str, permission_level: str = 'ow
             raise
 
 
+# TODO figure out what this function does, appears only within unit tests, but why pass back sorted_key?
 def get_collection(owner: str, collection_fqid: str):
     collection = dynamodb.get_item(table=collection_db_table,
                                    hash_key=owner,

--- a/dss/collections/owner_lookup.py
+++ b/dss/collections/owner_lookup.py
@@ -8,6 +8,7 @@ collection_db_table = f"dss-collections-db-{os.environ['DSS_DEPLOYMENT_STAGE']}"
 
 
 def put_collection(owner: str, collection_fqid: str, permission_level: str = 'owner'):
+    """Put a new collection FQID into the collection DB."""
     try:
         dynamodb.put_item(table=collection_db_table,
                           hash_key=owner,
@@ -19,12 +20,16 @@ def put_collection(owner: str, collection_fqid: str, permission_level: str = 'ow
             raise
 
 
-# TODO figure out what this function does, appears only within unit tests, but why pass back sorted_key?
-def get_collection(owner: str, collection_fqid: str):
-    collection = dynamodb.get_item(table=collection_db_table,
-                                   hash_key=owner,
-                                   sort_key=collection_fqid)
-    return collection.get('sort_key')
+def get_collection(owner: str, collection_fqid: str) -> None:
+    """
+    Get a collection FQID from the collection DB, and return it back.
+    This method is useful b/c it raises an exception if the given collection is not in the collection DB.
+    Also see scripts/update_collection_db.py
+    """
+    collection_record = dynamodb.get_item(table=collection_db_table,
+                                          hash_key=owner,
+                                          sort_key=collection_fqid)
+    return collection_record.get('sort_key')
 
 
 def get_collection_fqids_for_owner(owner: str):

--- a/dss/collections/owner_lookup.py
+++ b/dss/collections/owner_lookup.py
@@ -20,10 +20,10 @@ def put_collection(owner: str, collection_fqid: str, permission_level: str = 'ow
 
 
 def get_collection(owner: str, collection_fqid: str):
-    return dynamodb.get_item(table=collection_db_table,
-                             hash_key=owner,
-                             sort_key=collection_fqid,
-                             return_key='sort_key')
+    collection = dynamodb.get_item(table=collection_db_table,
+                                   hash_key=owner,
+                                   sort_key=collection_fqid)
+    return collection.get('sort_key')
 
 
 def get_collection_fqids_for_owner(owner: str):

--- a/dss/dynamodb/__init__.py
+++ b/dss/dynamodb/__init__.py
@@ -48,7 +48,7 @@ def put_item(*, table: str, hash_key: str, sort_key: Optional[str] = None, value
     db.put_item(**query)
 
 
-def get_item(*, table: str, hash_key: str, sort_key: Optional[str]) -> typing.Dict:
+def get_item(*, table: str, hash_key: str, sort_key: Optional[str] = None) -> typing.Dict:
     """
     Get associated value for a given set of keys from a dynamoDB table.
     :param table: Name of the table in AWS.

--- a/dss/dynamodb/__init__.py
+++ b/dss/dynamodb/__init__.py
@@ -7,6 +7,7 @@ from dss.util.aws.clients import dynamodb as db  # type: ignore
 class DynamoDBItemNotFound(Exception):
     pass
 
+
 class SchemaMismatch(Exception):
     pass
 

--- a/dss/dynamodb/__init__.py
+++ b/dss/dynamodb/__init__.py
@@ -7,7 +7,7 @@ from dss.util.aws.clients import dynamodb as db  # type: ignore
 class DynamoDBItemNotFound(Exception):
     pass
 
-class SchemaMissMatch(Exception):
+class SchemaMismatch(Exception):
     pass
 
 
@@ -47,13 +47,13 @@ def put_item(*, table: str, hash_key: str, sort_key: Optional[str] = None, value
     db.put_item(**query)
 
 
-def get_item(*, table: str, hash_key: str, sort_key: str = None) -> typing.Dict:
+def get_item(*, table: str, hash_key: str, sort_key: Optional[str]) -> typing.Dict:
     """
     Get associated value for a given set of keys from a dynamoDB table.
     :param table: Name of the table in AWS.
     :param str hash_key: 1st primary key that can be used to fetch associated sort_keys and values.
     :param str sort_key: 2nd primary key, used with hash_key to fetch a specific value.
-    :return: item object from ddb (dic)
+    :return: item object from ddb (dict), with attribute types omitted
     """
     return_value = {}
     query = {'TableName': table,
@@ -61,7 +61,7 @@ def get_item(*, table: str, hash_key: str, sort_key: str = None) -> typing.Dict:
     try:
         item = db.get_item(**query).get('Item')
     except db.exceptions.ValidationException:
-        raise SchemaMissMatch(f'Query schema {query} does not match table {table}')
+        raise SchemaMismatch(f'Query schema {query} does not match table {table}')
     if item is None:
         raise DynamoDBItemNotFound(f'Query failed to fetch item from database: {query}')
     for k, v in item.items():  # strips out ddb typing info

--- a/dss/dynamodb/__init__.py
+++ b/dss/dynamodb/__init__.py
@@ -143,27 +143,3 @@ def delete_item(*, table: str, hash_key: str, sort_key: Optional[str] = None):
     query = {'TableName': table,
              'Key': _format_item(hash_key=hash_key, sort_key=sort_key, value=None)}
     db.delete_item(**query)
-
-
-def update_item(*, table: str, hash_key: str, sort_key: Optional[str] = None, update_expression: Optional[str],
-                expression_attribute_values: typing.Dict):
-    """
-    Update an item from a dynamoDB table.
-    Will determine the type of db this is being called on by the number of keys provided (omit
-    sort_key to UPDATE from a db with only 1 primary key).
-    NOTE:
-    https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html
-    :param table: Name of the table in AWS.
-    :param str hash_key: 1st primary key that can be used to fetch associated sort_keys and values.
-    :param str sort_key: 2nd primary key, used with hash_key to fetch a specific value.
-                         Note: If not specified, this will DELETE only 1 key (hash_key) and 1 value.
-    :param str update_expression: Expression used to update value, needs action to be performed and new value
-    :param str expression_attribute_values: attribute values to use from the expression
-    :return: None
-    """
-    query = {'TableName': table,
-             'Key': _format_item(hash_key=hash_key, sort_key=sort_key, value=None)}
-    if update_expression:
-        query['UpdateExpression'] = update_expression
-        query['ExpressionAttributeValues'] = expression_attribute_values
-    db.update_item(**query)

--- a/dss/subscriptions_v2/__init__.py
+++ b/dss/subscriptions_v2/__init__.py
@@ -33,7 +33,8 @@ def get_subscription(replica: Replica, owner: str, uuid: str):
         item = dynamodb.get_item(table=subscription_db_table.format(replica.name),
                                  hash_key=owner,
                                  sort_key=uuid)
-        return json.loads(item)
+
+        return json.loads(item.get('body'))
     except dynamodb.DynamoDBItemNotFound:
         return None
 

--- a/dss/util/async_state.py
+++ b/dss/util/async_state.py
@@ -47,7 +47,7 @@ class AsyncStateItem:
     def get(cls, key: str) -> typing.Any:
         try:
             item = get_item(table=cls.table, hash_key=key)
-            body = json.loads(item)
+            body = json.loads(item.get('body'))
             item_class = _all_subclasses(cls)[body['_type']]
             return item_class(key, body)
         except DynamoDBItemNotFound:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,12 +258,14 @@ class TestDynamodbUtils(unittest.TestCase):
 
         formatted_item_attributes = {"sort_key": "02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z",
                                      "hash_key": "travis-test@platform-hca.iam.gserviceaccount.com",
-                                     "body": "owner"}
+                                     "body": "owner",
+                                     "list": ["GMAW", "FCAW", "GTAW"]}
 
         def mock_ddb_call():
             return {"Item": {"sort_key": {"S": "02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z"},
                              "hash_key": {"S": "travis-test@platform-hca.iam.gserviceaccount.com"},
-                             "body": {"S": "owner"}}}
+                             "body": {"S": "owner"},
+                             "list": {"SS": ["GMAW", "FCAW", "GTAW"]}}}
 
         with mock.patch('dss.dynamodb.db.get_item') as mock_get_item:
             mock_get_item.return_value = mock_ddb_call()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -259,13 +259,15 @@ class TestDynamodbUtils(unittest.TestCase):
         formatted_item_attributes = {"sort_key": "02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z",
                                      "hash_key": "travis-test@platform-hca.iam.gserviceaccount.com",
                                      "body": "owner",
-                                     "list": ["GMAW", "FCAW", "GTAW"]}
+                                     "string_set": ["GMAW", "FCAW", "GTAW"],
+                                     "list": [{"S": "Cookies"}, {"S": "Coffee"}, {"N", "3.14159"}]}
 
         def mock_ddb_call():
             return {"Item": {"sort_key": {"S": "02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z"},
                              "hash_key": {"S": "travis-test@platform-hca.iam.gserviceaccount.com"},
                              "body": {"S": "owner"},
-                             "list": {"SS": ["GMAW", "FCAW", "GTAW"]}}}
+                             "string_set": {"SS": ["GMAW", "FCAW", "GTAW"]},
+                             "list": {"L": [{"S": "Cookies"}, {"S": "Coffee"}, {"N", "3.14159"}]}}}
 
         with mock.patch('dss.dynamodb.db.get_item') as mock_get_item:
             mock_get_item.return_value = mock_ddb_call()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -254,7 +254,10 @@ class TestSecurity(unittest.TestCase):
 class TestDynamodbUtils(unittest.TestCase):
 
     def test_get_item(self):
-        """test out functionality of removing the attribute types from a dynamodb response"""
+        """
+        Test out functionality of removing the attribute types from a dynamodb response.
+        Example: {"foo": {"S": "bar"}} should become {"foo": "bar"}
+        """
 
         formatted_item_attributes = {"sort_key": "02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z",
                                      "hash_key": "travis-test@platform-hca.iam.gserviceaccount.com",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss import DSSException, DSSForbiddenException, Config
 from dss.config import Replica
+from dss.dynamodb import get_item
 from dss.logging import configure_test_logging
 from dss.util import UrlBuilder, security, multipart_parallel_upload
 from dss.util.aws import ARN
@@ -247,6 +248,30 @@ class TestSecurity(unittest.TestCase):
     @staticmethod
     def restore_email_claims(old):
         os.environ['OIDC_EMAIL_CLAIM'] = old
+
+
+@testmode.standalone
+class TestDynamodbUtils(unittest.TestCase):
+
+    def test_get_item(self):
+        """test out functionality of removing the attribute types from a dynamodb response"""
+
+        formatted_item_attributes = {"sort_key": "02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z",
+                                     "hash_key": "travis-test@platform-hca.iam.gserviceaccount.com",
+                                     "body": "owner"}
+
+        def mock_ddb_call():
+            return {"Item": {"sort_key": {"S": "02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z"},
+                             "hash_key": {"S": "travis-test@platform-hca.iam.gserviceaccount.com"},
+                             "body": {"S": "owner"}}}
+
+        with mock.patch('dss.dynamodb.db.get_item') as mock_get_item:
+            mock_get_item.return_value = mock_ddb_call()
+            data = get_item(table='mock_table', hash_key="travis-test@platform-hca.iam.gserviceaccount.com",
+                            sort_key="02434574-dbec-45dd-8bc5-d5dae7007780.2020-02-24T201715.601067Z")
+
+        self.assertDictEqual(data, formatted_item_attributes)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
update dynamodb get_item to return dictionary of item attributes rather than `body` or singular `return_key` 
added `update_item` functionality to add or update item to a ddb table

Connected to #74 