### PR TITLE
[Auth0 CRUD Part 3] Fix auth tests, add Auth0 auth tests

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -401,7 +401,8 @@ class Config:
                 val = Config._get_required_envvar("OIDC_AUTH0_TOKEN_CLAIM")
                 Config._OIDC_AUTH0_TOKEN_CLAIM = val
         else:
-            raise Exception(f"auth backend misconfigured: expected \"auth0\" but got \"{backend}\"")
+            raise Exception("auth backend misconfigured: Config.get_auth0_claim() expected "
+                            f"\"auth0\" but got \"{backend}\"")
 
         return Config._OIDC_AUTH0_TOKEN_CLAIM
 

--- a/dss/config.py
+++ b/dss/config.py
@@ -117,6 +117,7 @@ class Config:
     _NOTIFICATION_SENDER_EMAIL: typing.Optional[str] = None
     _ADMIN_USER_EMAILS_LIST: typing.Optional[typing.List[str]] = None
     _TRUSTED_GOOGLE_PROJECTS: typing.Optional[typing.List[str]] = None
+    _OIDC_AUTH0_TOKEN_CLAIM: typing.Optional[str] = None
     _OIDC_AUDIENCE: typing.Optional[typing.List[str]] = None
     _AUTH_URL: typing.Optional[str] = None
     _AUTH_BACKEND: typing.Optional[str] = None
@@ -391,6 +392,18 @@ class Config:
         val_list = [j.strip() for j in val_str.split(",")]
         Config._ADMIN_USER_EMAILS_LIST = val_list
         return Config._ADMIN_USER_EMAILS_LIST
+
+    @staticmethod
+    def get_auth0_claim():
+        backend = self.get_auth_backend()
+        if backend == "auth0":
+            if Config._OIDC_AUTH0_TOKEN_CLAIM is None:
+                val = Config._get_required_envvar("OIDC_AUTH0_TOKEN_CLAIM")
+                Config._OIDC_AUTH0_TOKEN_CLAIM = val
+        else:
+            raise Exception(f"auth backend misconfigured: expected \"auth0\" but got \"{backend}\"")
+
+        return Config._OIDC_AUTH0_TOKEN_CLAIM
 
     @staticmethod
     def debug_level() -> int:

--- a/dss/config.py
+++ b/dss/config.py
@@ -395,7 +395,7 @@ class Config:
 
     @staticmethod
     def get_auth0_claim():
-        backend = self.get_auth_backend()
+        backend = Config.get_auth_backend()
         if backend == "auth0":
             if Config._OIDC_AUTH0_TOKEN_CLAIM is None:
                 val = Config._get_required_envvar("OIDC_AUTH0_TOKEN_CLAIM")

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -33,23 +33,21 @@ class Auth0AuthZGroupsMixin(Authorize):
     (Note: the Auth0 AuthZ extension adds groups, roles, and permissions,
     but here we just use groups.)
     """
-    def _get_auth0authz_claim(self):
+    @classmethod
+    def get_auth0authz_claim(self):
         oidc_audience = Config.get_audience()[0]
         return f"{oidc_audience}auth0"
-
-    def _get_auth0authz_group_claim(self):
-        return "groups"
 
     @property
     def auth0authz_groups(self):
         """Property for the groups added to the JWT by the Auth0 AuthZ plugin"""
         # First get the portion of the token added by the Auth0 AuthZ extension
-        auth0authz_claim = self._get_auth0authz_claim()
+        auth0authz_claim = self.get_auth0authz_claim()
         self.assert_required_parameters(self.token, [auth0authz_claim])
         auth0authz_token = self.token[auth0authz_claim]
 
         # Second extract the groups from this portion
-        auth0authz_groups_claim = self._get_auth0authz_groups_claim()
+        auth0authz_groups_claim = "groups"
         self.assert_required_parameters(auth0authz_token, [auth0authz_groups_claim])
         groups = self.token[auth0authz_claim][auth0authz_groups_claim]
         return groups

--- a/dss/util/auth/authorize.py
+++ b/dss/util/auth/authorize.py
@@ -111,12 +111,12 @@ class TokenEmailMixin(TokenMixin):
 
 def always_allow_admins(f):
     """Decorate an auth check so that admins are always allowed"""
-    def wrapper(*args):
-        slf = args[0]
+    def wrapper(*args, **kwargs):
+        slf = args[0]  # arg[0] of method call is self
         if slf._is_admin():
             return  # Skip calling the auth function altogether
         else:
-            return f(*args)
+            return f(*args, **kwargs)
     return wrapper
 
 

--- a/environment
+++ b/environment
@@ -137,6 +137,7 @@ AUTH_URL=https://dev-4lyab62k.auth0.com
 OPENID_PROVIDER=https://dev-4lyab62k.auth0.com/
 OIDC_EMAIL_CLAIM="${OIDC_AUDIENCE}email"
 OIDC_GROUP_CLAIM="${OIDC_AUDIENCE}group"
+OIDC_AUTH0_TOKEN_CLAIM="${OIDC_AUDIENCE}auth0"
 AUTH_BACKEND=Fusillade
 
 NOTIFY_URL=https://${API_DOMAIN_NAME}/internal/notify

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -185,14 +185,14 @@ class TestAuth0Auth(unittest.TestCase):
         with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
             with mock.patch('dss.util.auth.authorize.Authorize.token', token):
                 auth = AuthWrapper()
-                auth.security_flow(method='create', groups=[allowed_grp])
-                auth.security_flow(method='read')
-                auth.security_flow(method='update', groups=[allowed_grp])
+                auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore 
+                auth.security_flow(method='read')  # type: ignore 
+                auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore 
                 if admin:
-                    auth.security_flow(method='delete')
+                    auth.security_flow(method='delete')  # type: ignore 
                 else:
                     with self.assertRaises(DSSForbiddenException):
-                        auth.security_flow(method='delete')
+                        auth.security_flow(method='delete')  # type: ignore 
 
 
 if __name__ == "__main__":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,11 +15,21 @@ from dss.util.auth.authorize import (AuthorizeBase, TokenMixin, TokenGroupMixin,
 from tests.infra import testmode
 
 
-def get_group_claim_token(grp):
-    return {os.environ['OIDC_GROUP_CLAIM']: grp}
+def get_token_issuer_claim_ok(iss):
+    return {'iss': iss}
 
-def get_email_claim_token(eml):
-    return {os.environ['OIDC_EMAIL_CLAIM']: eml}
+def get_token_group_claim_ok(grp):
+    return {Config.get_OIDC_group_claim(): grp}
+
+
+def get_token_email_claim_ok(eml):
+    return {Config.get_OIDC_email_claim(): eml}
+
+
+def get_token_admin_claim_ok():
+    admin_user_emails = Config.get_admin_user_emails()
+    return {Config.get_OIDC_email_claim(): admin_user_emails[0]}
+
 
 class TestAuthBase(unittest.TestCase):
     """
@@ -29,13 +39,13 @@ class TestAuthBase(unittest.TestCase):
     def setUpClass(cls):
         dss.Config.set_config(dss.BucketConfig.TEST)
 
-    def test_auth_security_flow(self):
+    def test_base_auth_security_flow(self):
         # Virtual methods gonna virtual
         a = AuthorizeBase()
         with self.assertRaises(NotImplementedError):
             a.security_flow()
 
-    def test_assert_required_parameters(self):
+    def test_base_assert_required_parameters(self):
         params = {
             'foo': 'bar',
             'baz': 'wuz'
@@ -54,31 +64,33 @@ class TestAuthMixins(unittest.TestCase):
         dss.Config.set_config(dss.BucketConfig.TEST)
 
     def test_token_mixin(self):
-        # Check that when you set the token property on
-        # a TokenMixin instance, you get the token property
         tm = TokenMixin()
-        valid_token = get_group_claim_token('dbio')
-        invalid_token = get_group_claim_token('boo-this-is-an-invalid-token-group')
+        valid_token = get_token_issuer_claim_ok(Config.get_openid_provider())
+        invalid_token = get_token_issuer_claim_ok("dss-testauth-test_token_mixin-invalid_issuer")
         with mock.patch('dss.util.auth.authorize.TokenMixin.token', valid_token):
             self.assertEquals(tm.token, valid_token)
-            self.assertNotEquals(tm.token, invalid_token)
+            tm._assert_authorized_issuer()
+        with mock.patch('dss.util.auth.authorize.TokenMixin.token', invalid_token):
+            self.assertEquals(tm.token, invalid_token)
+            with self.assertRaises(DSSException):
+                tm._assert_authorized_issuer()
 
-    def test_group_token_mixin(self):
+    def test_token_group_mixin(self):
         tgm = TokenGroupMixin()
         grp = 'dbio'
-        valid_token = get_group_claim_token(grp)
-        invalid_token = get_group_claim_token('boo-this-is-an-invalid-token-group')
+        valid_token = get_token_group_claim_ok(grp)
+        invalid_token = get_token_group_claim_ok('boo-this-is-an-invalid-token-group')
         with mock.patch('dss.util.auth.authorize.TokenGroupMixin.token', valid_token):
             tgm._assert_authorized_group([grp])
         with mock.patch('dss.util.auth.authorize.TokenGroupMixin.token', invalid_token):
             with self.assertRaises(DSSException):
                 tgm._assert_authorized_group([grp])
 
-    def test_email_token_mixin(self):
+    def test_token_email_mixin(self):
         tem = TokenEmailMixin()
-        eml = 'valid-email@dss-testauth-testemailtokenmixin.ucsc.edu'
-        valid_token = get_email_claim_token(eml)
-        invalid_token = get_email_claim_token(f'not-a-valid-email')
+        eml = 'valid-email@dss-testauth-test_token_email_mixin.ucsc-cgp-redwood.org'
+        valid_token = get_token_email_claim_ok(eml)
+        invalid_token = get_token_email_claim_ok(f'not-a-valid-email')
         # Check valid and invalid tokens
         with mock.patch('dss.util.auth.authorize.TokenEmailMixin.token', valid_token):
             tem._assert_authorized_email([eml])
@@ -91,33 +103,26 @@ class TestFusilladeAuth(unittest.TestCase):
     """
     Test security flow for Fusillade authentication and authorization layer.
     """
-
     def test_authorized_security_flow(self):
-        valid_token = get_group_claim_token('dbio')
+        valid_grp = 'dbio'
+        valid_token = get_token_group_claim_ok(valid_grp)
         with mock.patch('dss.util.auth.authorize.Authorize.token', valid_token):
 
             # Test that security flow succeeds for each auth backend
             with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
                 auth = AuthWrapper()
-                auth.security_flow(groups=['dbio'])
-            with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
-                auth = AuthWrapper()
-                auth.security_flow(method='create', groups=['dbio'])
-                auth.security_flow(method='read')
-                auth.security_flow(method='update')
-                auth.security_flow(method='delete')
+                auth.security_flow(groups=[valid_grp])
 
     def test_unauthorized_security_flow(self):
         invalid_token = {}
         with mock.patch('dss.util.auth.authorize.Authorize.token', invalid_token):
-
-            # Test that security flow fails for each auth backend
+            # Set auth backend
             with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
+                valid_grp = 'dbio'
                 # Check failure due to empty token
                 with self.assertRaises(DSSForbiddenException):
                     auth = AuthWrapper()
-                    auth.security_flow(groups=['dbio'])
-
+                    auth.security_flow(groups=[valid_grp])
                 # Check failure due to invalid method signature
                 with self.assertRaises(DSSException):
                     auth = AuthWrapper()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,7 +2,6 @@
 import io
 import os
 import sys
-import json
 import unittest
 from unittest import mock
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -158,7 +158,7 @@ class TestAuth0Auth(unittest.TestCase):
 
     def test_unauthorized_security_flow(self):
         valid_grp = 'dbio'
-        invalid_grp = 'not-a-valid-group-not-even-a-little-bit'
+        invalid_grp = 'not-a-valid-group_dss_test-auth_test-auth0'
         invalid_token = get_token_group_claim(invalid_grp)
         with self.assertRaises(DSSException):
             self._test_security_flow(invalid_token, valid_grp)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -149,7 +149,7 @@ class TestAuthMixins(unittest.TestCase):
         valid_token = get_token_auth0_claim(valid_group, valid_auth0authz_group)
         with mock.patch('dss.util.auth.auth0.Auth0AuthZGroupsMixin.token', valid_token):
             # Test access to A0AZ groups attribute
-            self.assertEqual(a0az.auth0authz_groups(), [valid_auth0authz_group])
+            self.assertEqual(a0az.auth0authz_groups, [valid_auth0authz_group])
             # Test ability to determine if A0AZ groups intersect a provided list
             all_groups = [valid_auth0authz_group, invalid_auth0authz_group]
             self.assertTrue(a0az.assert_auth0authz_groups_intersects(all_groups))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -128,5 +128,70 @@ class TestFusilladeAuth(unittest.TestCase):
                     auth = AuthWrapper()
                     auth.security_flow()
 
+
+class TestAuth0Auth(unittest.TestCase):
+    """
+    Test security flow for Auth0 authentication and authorization layer.
+    """
+    def test_authorized_security_flow(self):
+        """
+        Create a token with a valid group claim, and run through the normal security flow to check for
+        a valid group claim.
+        """
+        valid_grp = 'dbio'
+        valid_token = get_token_group_claim_ok(valid_grp)
+        with mock.patch('dss.util.auth.authorize.Authorize.token', valid_token):
+            with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
+                auth = AuthWrapper()
+                auth.security_flow(method='create', groups=[valid_grp])
+                auth.security_flow(method='read')
+                auth.security_flow(method='update', groups=[valid_grp])
+                # Admins only
+                with self.assertRaises(DSSForbiddenException):
+                    auth.security_flow(method='delete')
+
+    def test_admin_security_flow(self):
+        """
+        Create a token for an admin user, and run through the security flow to verify admins are allowed
+        to do all actions.
+        """
+        admin_token = get_token_admin_claim_ok()
+        with mock.patch('dss.util.auth.authorize.Authorize.token', admin_token):
+            with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
+                auth = AuthWrapper()
+                valid_grp = 'dbio'
+                # These should all allow admins
+                auth.security_flow(method='create', groups=[valid_grp])
+                auth.security_flow(method='read')
+                auth.security_flow(method='update', groups=[valid_grp])
+                # Admins only
+                auth.security_flow(method='delete')
+
+    def test_unauthorized_security_flow(self):
+        """
+        Create an invalid (empty) token, and run through the security flow to verify unauthorized users
+        are only allowed a limited set of actions.
+        """
+        invalid_token = {}
+        with mock.patch('dss.util.auth.authorize.Authorize.token', invalid_token):
+            # Set auth backend
+            with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
+                valid_grp = 'dbio'
+                # Check failure due to empty token
+                auth = AuthWrapper()
+                with self.assertRaises(DSSForbiddenException):
+                    auth.security_flow(method='create', groups=[valid_grp])
+                    auth.security_flow(method='update', groups=[valid_grp])
+                with self.assertRaises(DSSException):
+                    auth.security_flow(method='delete')
+                # Check failure due to invalid method signature
+                auth = AuthWrapper()
+                with self.assertRaises(DSSException):
+                    auth.security_flow()  # Missing required method kwarg
+                    auth.security_flow(method='create')  # Missing required groups kwarg
+                    auth.security_flow(method='update')  # Missing required groups kwarg
+                    auth.security_flow(method='delete')  # Not an admin
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -152,7 +152,7 @@ class TestAuthMixins(unittest.TestCase):
             self.assertEqual(a0az.auth0authz_groups(), [valid_auth0authz_group])
             # Test ability to determine if A0AZ groups intersect a provided list
             all_groups = [valid_auth0authz_group, invalid_auth0authz_group]
-            self.assertTrue(a0az.assert_auth0authz_groups_intersects(all_groups)
+            self.assertTrue(a0az.assert_auth0authz_groups_intersects(all_groups))
 
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -179,10 +179,9 @@ class TestAuth0Auth(unittest.TestCase):
                 valid_grp = 'dbio'
                 # Check failure due to empty token
                 auth = AuthWrapper()
-                with self.assertRaises(DSSForbiddenException):
+                with self.assertRaises(DSSException):
                     auth.security_flow(method='create', groups=[valid_grp])
                     auth.security_flow(method='update', groups=[valid_grp])
-                with self.assertRaises(DSSException):
                     auth.security_flow(method='delete')
                 # Check failure due to invalid method signature
                 auth = AuthWrapper()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,25 +17,25 @@ from tests.infra import testmode
 from tests import get_service_jwt, UNAUTHORIZED_GCP_CREDENTIALS
 
 
-def get_token_issuer_claim(iss):
+def get_token_issuer_claim(iss: str) -> dict:
     token = {}
     token['iss'] = iss
     return token
 
 
-def get_token_email_claim(eml):
+def get_token_email_claim(eml: str) -> dict:
     token = get_token_issuer_claim('')
     token[Config.get_OIDC_email_claim()] = eml
     return token
 
 
-def get_token_group_claim(grp):
+def get_token_group_claim(grp: str) -> dict:
     token = get_token_email_claim('')
     token[Config.get_OIDC_group_claim()] = grp
     return token
 
 
-def get_token_admin_claim():
+def get_token_admin_claim() -> dict:
     token = get_token_issuer_claim('')
     admin_user_emails = Config.get_admin_user_emails()
     token[Config.get_OIDC_email_claim()] = admin_user_emails[0]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -140,7 +140,7 @@ class TestFusilladeAuth(unittest.TestCase):
             # Test that security flow succeeds for each auth backend
             with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
                 auth = AuthWrapper()
-                auth.security_flow(groups=[allowed_grp])
+                auth.security_flow(groups=[allowed_grp])  # type: ignore
 
 
 class TestAuth0Auth(unittest.TestCase):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -185,14 +185,14 @@ class TestAuth0Auth(unittest.TestCase):
         with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
             with mock.patch('dss.util.auth.authorize.Authorize.token', token):
                 auth = AuthWrapper()
-                auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore 
-                auth.security_flow(method='read')  # type: ignore 
-                auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore 
+                auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore
+                auth.security_flow(method='read')  # type: ignore
+                auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
                 if admin:
-                    auth.security_flow(method='delete')  # type: ignore 
+                    auth.security_flow(method='delete')  # type: ignore
                 else:
                     with self.assertRaises(DSSForbiddenException):
-                        auth.security_flow(method='delete')  # type: ignore 
+                        auth.security_flow(method='delete')  # type: ignore
 
 
 if __name__ == "__main__":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -44,7 +44,7 @@ def get_token_auth0_claim(grp: str, auth0authzgrp: str, eml: str = '', iss: str 
     token = get_token_group_claim(grp, eml, iss)
     auth0claim = Auth0AuthZGroupsMixin.get_auth0authz_claim()
     token[auth0claim] = {
-        "groups": [auth0authzgrp]
+        "groups": [auth0authzgrp],
         "roles": [],
         "permissions": []
     }
@@ -153,7 +153,6 @@ class TestAuthMixins(unittest.TestCase):
             # Test ability to determine if A0AZ groups intersect a provided list
             all_groups = [valid_auth0authz_group, invalid_auth0authz_group]
             self.assertTrue(a0az.assert_auth0authz_groups_intersects(all_groups))
-
 
 
 class TestFusilladeAuth(unittest.TestCase):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -123,13 +123,6 @@ class TestFusilladeAuth(unittest.TestCase):
     """
     Test security flow for Fusillade authentication and authorization layer.
     """
-    def _test_security_flow(self, token: dict, allowed_grp: str):
-        with mock.patch('dss.util.auth.authorize.Authorize.token', token):
-            # Test that security flow succeeds for each auth backend
-            with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
-                auth = AuthWrapper()
-                auth.security_flow(groups=[allowed_grp])
-
     def test_authorized_security_flow(self):
         valid_grp = 'dbio'
         valid_token = get_token_group_claim(valid_grp)
@@ -137,25 +130,17 @@ class TestFusilladeAuth(unittest.TestCase):
 
     def test_unauthorized_security_flow(self):
         valid_grp = 'dbio'
-        invalid_grp = 'not-a-valid-grp'
+        invalid_grp = 'not-a-valid-grp_dss_test-auth_test-fusillade'
         invalid_token = get_token_group_claim(invalid_grp)
         with self.assertRaises(DSSException):
             self._test_security_flow(invalid_token, valid_grp)
 
-    def test_unauthorized_security_flow(self):
-        valid_grp = 'dbio'
-        invalid_grp = 'not-a-valid-grp'
-        invalid_token = {}
-        grpinvalid_token = get_token_group_claim(invalid_grp)
-        with mock.patch('dss.util.auth.authorize.Authorize.token', invalid_token):
+    def _test_security_flow(self, token: dict, allowed_grp: str):
+        with mock.patch('dss.util.auth.authorize.Authorize.token', token):
+            # Test that security flow succeeds for each auth backend
             with mock.patch("dss.Config.get_auth_backend", return_value="fusillade"):
-                valid_grp = 'dbio'
-                with self.assertRaises(DSSException):
-                    auth = AuthWrapper()
-                    # Check failure due to empty token
-                    auth.security_flow(groups=[valid_grp])
-                    # Check failure due to invalid method signature
-                    auth.security_flow()
+                auth = AuthWrapper()
+                auth.security_flow(groups=[allowed_grp])
 
 
 class TestAuth0Auth(unittest.TestCase):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -76,7 +76,7 @@ class TestAuthMixins(unittest.TestCase):
     def test_token_mixin(self):
         tm = TokenMixin()
         valid_token = get_token_issuer_claim(Config.get_openid_provider())
-        invalid_token = get_token_issuer_claim("dss_test-auth_test-token-mixin")
+        invalid_token = get_token_issuer_claim("invalid-issuer-auth_dss_test-auth_test-token-mixin")
         with mock.patch('dss.util.auth.authorize.TokenMixin.token', valid_token):
             self.assertEquals(tm.token, valid_token)
             tm._assert_authorized_issuer()
@@ -89,7 +89,7 @@ class TestAuthMixins(unittest.TestCase):
         tgm = TokenGroupMixin()
         valid_group = 'dbio'
         valid_token = get_token_group_claim(valid_group)
-        invalid_token = get_token_group_claim('dss_test-auth_test-token-group-mixin')
+        invalid_token = get_token_group_claim("invalid-group_dss_test-auth_test-token-group-mixin")
         with mock.patch('dss.util.auth.authorize.TokenGroupMixin.token', valid_token):
             tgm._assert_authorized_group([valid_group])
         with mock.patch('dss.util.auth.authorize.TokenGroupMixin.token', invalid_token):


### PR DESCRIPTION
This fixes existing auth tests in `tests/test_auth.py` and adds tests for the Auth0 Authorization class.

Part 1: #130 (adds mixins for FLAC and Auth0AuthZ extensions, adds parameter checks)

Part 2: #135 (handles case of admin action)

Part 3: #136 (expands and updates tests, updates and fixes auth API)