### PR TITLE
[EASY] Update audience domain used in test_utils.py

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,15 +144,15 @@ class TestSecurity(unittest.TestCase):
                 with self.assertRaises(DSSForbiddenException):
                     security.assert_authorized_group(['dbio'], token_info)
 
-    @mock.patch('dss.Config._OIDC_AUDIENCE', new=["https://dev.data.humancellatlas.org/",
-                                                  "https://data.humancellatlas.org/"])
+    @mock.patch('dss.Config._OIDC_AUDIENCE', new=["https://dev.ucsc-cgp-redwood.org/",
+                                                  "https://data.ucsc-cgp-redwood.org/"])
     @mock.patch('dss.Config._TRUSTED_GOOGLE_PROJECTS', new=['cool-project-188401.iam.gserviceaccount.com'])
     def test_verify_jwt_multiple_audience(self):
         jwts_positive = [
             get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS),
-            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="https://dev.data.humancellatlas.org/"),
-            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="https://data.humancellatlas.org/"),
-            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience=["https://dev.data.humancellatlas.org/", "e"])
+            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="https://dev.ucsc-cgp-redwood.org/"),
+            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="https://data.ucsc-cgp-redwood.org/"),
+            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience=["https://dev.ucsc-cgp-redwood.org/", "e"])
         ]
         jwt_negative = [
             get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="something else"),
@@ -165,13 +165,13 @@ class TestSecurity(unittest.TestCase):
             with self.subTest("Negative: " + jwt):
                 self.assertRaises(dss.error.DSSException, security.verify_jwt, jwt)
 
-    @mock.patch('dss.Config._OIDC_AUDIENCE', new="https://dev.data.humancellatlas.org/")
+    @mock.patch('dss.Config._OIDC_AUDIENCE', new="https://dev.ucsc-cgp-redwood.org/")
     @mock.patch('dss.Config._TRUSTED_GOOGLE_PROJECTS', new=['cool-project-188401.iam.gserviceaccount.com'])
     def test_verify_jwt_single_audience(self):
         jwts_positive = [
             get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS),
-            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="https://dev.data.humancellatlas.org/"),
-            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience=["https://dev.data.humancellatlas.org/", "e"])
+            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="https://dev.ucsc-cgp-redwood.org/"),
+            get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience=["https://dev.ucsc-cgp-redwood.org/", "e"])
         ]
         jwt_negative = [
             get_service_jwt(UNAUTHORIZED_GCP_CREDENTIALS, audience="something else"),


### PR DESCRIPTION
Update `test_utils.py` to use ucsc-cgp-redwood.org domain for the OIDC audience.

This is an aesthetic fix only. These fixes are not necessary for tests to pass. The audience value is ultimately arbitrary. Life is meaningless.