### PR TITLE
Add docstring to explain get_collection method

### DIFF
--- a/dss/collections/owner_lookup.py
+++ b/dss/collections/owner_lookup.py
@@ -8,6 +8,7 @@ collection_db_table = f"dss-collections-db-{os.environ['DSS_DEPLOYMENT_STAGE']}"
 
 
 def put_collection(owner: str, collection_fqid: str, permission_level: str = 'owner'):
+    """Put a new collection FQID into the collection DB."""
     try:
         dynamodb.put_item(table=collection_db_table,
                           hash_key=owner,
@@ -19,12 +20,15 @@ def put_collection(owner: str, collection_fqid: str, permission_level: str = 'ow
             raise
 
 
-# TODO figure out what this function does, appears only within unit tests, but why pass back sorted_key?
-def get_collection(owner: str, collection_fqid: str):
-    collection = dynamodb.get_item(table=collection_db_table,
-                                   hash_key=owner,
-                                   sort_key=collection_fqid)
-    return collection.get('sort_key')
+def get_collection(owner: str, collection_fqid: str) -> None:
+    """
+    Get a collection FQID from the collection DB, and return it back.
+    This method is useful b/c it raises exception if the given collection is not in the collection DB.
+    """
+    collection_record = dynamodb.get_item(table=collection_db_table,
+                                          hash_key=owner,
+                                          sort_key=collection_fqid)
+    return collection_record['sort_key']
 
 
 def get_collection_fqids_for_owner(owner: str):

--- a/dss/collections/owner_lookup.py
+++ b/dss/collections/owner_lookup.py
@@ -28,7 +28,7 @@ def get_collection(owner: str, collection_fqid: str) -> None:
     collection_record = dynamodb.get_item(table=collection_db_table,
                                           hash_key=owner,
                                           sort_key=collection_fqid)
-    return collection_record['sort_key']
+    return collection_record.get('sort_key')
 
 
 def get_collection_fqids_for_owner(owner: str):

--- a/dss/collections/owner_lookup.py
+++ b/dss/collections/owner_lookup.py
@@ -23,7 +23,8 @@ def put_collection(owner: str, collection_fqid: str, permission_level: str = 'ow
 def get_collection(owner: str, collection_fqid: str) -> None:
     """
     Get a collection FQID from the collection DB, and return it back.
-    This method is useful b/c it raises exception if the given collection is not in the collection DB.
+    This method is useful b/c it raises an exception if the given collection is not in the collection DB.
+    Also see scripts/update_collection_db.py
     """
     collection_record = dynamodb.get_item(table=collection_db_table,
                                           hash_key=owner,


### PR DESCRIPTION
This addresses the discussion in PR #133 (https://github.com/DataBiosphere/data-store/pull/133/files#r386717524) by adding a docstring to explain why the `get_collection()` method returns the same information that the user provides to it. (Spoiler alert: it's because the method is only used to raise an exception if a given collection does _not_ exist in the collection database.)

Hopefully this PR will put the discussion to rest!