### PR TITLE
[EASY] Hotfix to convert admin emails to lowercase

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -389,7 +389,7 @@ class Config:
     @staticmethod
     def get_admin_user_emails() -> typing.List[str]:
         val_str = Config._get_required_envvar("ADMIN_USER_EMAILS")
-        val_list = [j.strip() for j in val_str.split(",")]
+        val_list = [j.strip().lower() for j in val_str.split(",")]
         Config._ADMIN_USER_EMAILS_LIST = val_list
         return Config._ADMIN_USER_EMAILS_LIST
 

--- a/dss/util/auth/authorize.py
+++ b/dss/util/auth/authorize.py
@@ -133,7 +133,7 @@ class AdminStatusMixin(TokenGroupMixin, TokenEmailMixin):
     def _is_admin(self):
         """Boolean property: is token_email an admin email?"""
         if self.token_email:
-            if self.token_email in self.admin_emails:
+            if self.token_email.lower() in self.admin_emails:
                 return True
         return False
 


### PR DESCRIPTION
This PR fixes the way the admin emails are obtained from the Config class so that they are all converted to lowercase when they are grabbed from the env config. It also fixes the way it compares the JWT email claim to the admin emails so that the email claim is also lowercase.

This PR raises questions about other group/email comparison mechanisms in the security class, and whether they would break if an email or group name were capitalized. But that's for another day...