### PR TITLE
[Enable Auth0 Part 2/4] DSS Auth: Fix decorators before unleashing Auth0

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -49,7 +49,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(groups=['dbio'])
+@security.assert_security(method='read', groups=['dbio'])
 def list_collections(per_page: int, start_at: int = 0):
     """
     Return a list of a user's collections.
@@ -87,7 +87,7 @@ def list_collections(per_page: int, start_at: int = 0):
 
 
 @dss_handler
-@security.assert_security(groups=['dbio'])
+@security.assert_security(method='read', groups=['dbio'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)
@@ -97,7 +97,7 @@ def get(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(groups=['dbio'])
+@security.assert_security(method='create', groups=['dbio'])
 def put(json_request_body: dict, replica: str, uuid: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = dict(json_request_body, owner=authenticated_user_email)
@@ -118,7 +118,7 @@ def put(json_request_body: dict, replica: str, uuid: str, version: str):
 
 
 @dss_handler
-@security.assert_security(groups=['dbio'])
+@security.assert_security(method='update', groups=['dbio'])
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 
@@ -157,7 +157,7 @@ def _dedpuplicate_contents(contents: List) -> List:
 
 
 @dss_handler
-@security.assert_security(groups=['dbio'])
+@security.assert_security(method='delete', groups=['dbio'])
 def delete(uuid: str, replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -188,7 +188,7 @@ def _verify_checkout(
 
 
 @dss_handler
-@security.assert_security(groups=['dbio'])
+@security.assert_security(method='create', groups=['dbio'])
 def put(uuid: str, json_request_body: dict, version: str):
     class CopyMode(Enum):
         NO_COPY = auto()

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -19,7 +19,7 @@ from dss.config import SUBSCRIPTION_LIMIT
 logger = logging.getLogger(__name__)
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='read', groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 
@@ -45,7 +45,7 @@ def get(uuid: str, replica: str):
     return jsonify(source), requests.codes.okay
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='read', groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     es_client = ElasticsearchClient.get()
@@ -66,7 +66,7 @@ def find(replica: str):
     return jsonify(full_response), requests.codes.okay
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='create', groups=['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     uuid = str(uuid4())
     es_query = json_request_body['es_query']
@@ -153,7 +153,7 @@ def put(json_request_body: dict, replica: str):
     return jsonify(dict(uuid=uuid)), requests.codes.created
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='delete', groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -17,7 +17,7 @@ from dss.subscriptions_v2 import (SubscriptionData,
                                   count_subscriptions_for_owner)
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='read', groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)
@@ -28,7 +28,7 @@ def get(uuid: str, replica: str):
     return subscription, requests.codes.ok
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='read', groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     subscriptions = get_subscriptions_for_owner(Replica[replica], owner)
@@ -39,7 +39,7 @@ def find(replica: str):
     return {'subscriptions': subscriptions}, requests.codes.ok
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='create', groups=['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     owner = security.get_token_email(request.token_info)
     if count_subscriptions_for_owner(Replica[replica], owner) > SUBSCRIPTION_LIMIT:
@@ -83,7 +83,7 @@ def put(json_request_body: dict, replica: str):
     return subscription_doc, requests.codes.created
 
 
-@security.assert_security(groups=['dbio', 'public'])
+@security.assert_security(method='delete', groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)

--- a/dss/config.py
+++ b/dss/config.py
@@ -116,6 +116,7 @@ class Config:
     _CURRENT_CONFIG: BucketConfig = BucketConfig.ILLEGAL
     _NOTIFICATION_SENDER_EMAIL: typing.Optional[str] = None
     _ADMIN_USER_EMAILS_LIST: typing.Optional[typing.List[str]] = None
+    _SERVICE_ACCT_EMAIL: typing.Optional[str] = None
     _TRUSTED_GOOGLE_PROJECTS: typing.Optional[typing.List[str]] = None
     _OIDC_AUTH0_TOKEN_CLAIM: typing.Optional[str] = None
     _OIDC_AUDIENCE: typing.Optional[typing.List[str]] = None
@@ -459,6 +460,14 @@ class Config:
         if Config._AUTH_BACKEND is None:
             Config._AUTH_BACKEND = Config._get_required_envvar("AUTH_BACKEND")
         return Config._AUTH_BACKEND
+
+    @staticmethod
+    def get_service_account_email():
+        if Config._SERVICE_ACCT_EMAIL is None:
+            ename = Config._get_required_envvar('DSS_GCP_SERVICE_ACCOUNT_NAME')
+            edomain = Config._get_required_envvar('DSS_AUTHORIZED_DOMAINS_TEST')
+            Config._SERVICE_ACCT_EMAIL = f"{ename}@{edomain}"
+        return Config._SERVICE_ACCT_EMAIL
 
     @staticmethod
     def get_ServiceAccountManager() -> security.DCPServiceAccountManager:

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -68,10 +68,10 @@ class Auth0(FlacMixin, Auth0AuthZGroupsMixin):
     create/read/update/delete operations.
 
     Decorator examples:
-    @security.assert_authorize(method='create', groups=['dbio', 'grp'])
-    @security.assert_authorize(method='read')
-    @security.assert_authorize(method='update', groups=['dbio', 'grp'])
-    @security.assert_authorize(method='delete')
+    @security.assert_security(method='create', groups=['dbio', 'grp'])
+    @security.assert_security(method='read')
+    @security.assert_security(method='update', groups=['dbio', 'grp'])
+    @security.assert_security(method='delete')
     """
     def __init__(self):
         self.session = requests.Session()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -106,7 +106,7 @@ def get_service_jwt(service_credentials, group: str = None, email=True, email_cl
     return signed_jwt
 
 
-def get_auth_header(real_header=True, authorized=True, group='dbio', email=True, email_claim=False):
+def get_auth_header(real_header=True, authorized=True, group='dbio', email=True, email_claim=True):
     if authorized:
         credential_file = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
         with io.open(credential_file) as fh:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -51,7 +51,9 @@ from dss.storage.identifiers import BundleFQID, ObjectIdentifier
 from dss.util import UrlBuilder, networking, RequirementError
 from dss.util.version import datetime_to_version_format
 from dss.util.time import SpecificRemainingTime
-from tests import eventually, get_auth_header, get_bundle_fqid, get_file_fqid, get_version
+from tests import (
+    eventually, get_auth_header, get_bundle_fqid, get_file_fqid, get_version, UNAUTHORIZED_GCP_CREDENTIALS
+)
 from tests.infra import DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, TestBundle, testmode
 from tests.infra.elasticsearch_test_case import ElasticsearchTestCase
 from tests.infra.server import ThreadedLocalServer, MockFusilladeHandler
@@ -400,7 +402,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                 _notify("https://127.0.0.1")
 
     @testmode.always
-    def test_notifications_recieved(self):
+    def test_notifications_received(self):
         endpoint = self._default_endpoint()
         endpoint = NotificationRequestHandler.configure(endpoint)
         subscription_id = self.subscribe_for_notification(es_query=smartseq2_paired_ends_vx_query,
@@ -471,7 +473,17 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         url = str(UrlBuilder().set(path=f"/v1/subscriptions/{subscription_id}")
                   .add_query("replica", self.replica.name)
                   .add_query("subscription_type", "elasticsearch"))
-        self.assertDeleteResponse(url, requests.codes.ok, headers=get_auth_header())
+
+        # This is where we want to do a mock patch
+        # (how to get the deleting user?)
+        # get_auth_header -> jwt_service_token -> various ways of populating email claim
+        deleting_users = [
+            Config.get_service_account_email(),
+            UNAUTHORIZED_GCP_CREDENTIALS['client_email']
+        ]
+        with unittest.mock.patch("dss.Config.get_admin_user_emails", return_value=deleting_users):
+            # This API endpoint will check if the user is an admin, hence the patch above
+            self.assertDeleteResponse(url, requests.codes.ok, headers=get_auth_header())
 
     @testmode.always
     def test_subscription_notification_successful(self):
@@ -497,7 +509,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                         for payload_form_field in None, 'z':
                             # form_fields and payload_form_field are only relevant with form-data encoding
                             if encoding != MIME.json or form_fields is None and payload_form_field is None:
-                                for verify_payloads in False, True:
+                                for verify_payloads in True, False:
                                     test_case(verify_payloads=verify_payloads,
                                               method=method,
                                               encoding=encoding,


### PR DESCRIPTION
The Auth0 auth backend requires the security decorators to specify a method keyword. This PR makes the corresponding change to each decorated endpoint.

It also updates security decorator examples in the Auth0 auth class's docstring.

Part 1: unleash auth0: https://github.com/DataBiosphere/data-store/pull/146
Part 2: fix decorators for auth0: https://github.com/DataBiosphere/data-store/pull/148
Part 3: fix tests: https://github.com/DataBiosphere/data-store/pull/149
Part 4: update config: https://github.com/DataBiosphere/data-store/pull/151