### PR TITLE
[Enable Auth0 Part 3/4] DSS Auth: Fix token generation for tests before unleashing Auth0

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -116,6 +116,7 @@ class Config:
     _CURRENT_CONFIG: BucketConfig = BucketConfig.ILLEGAL
     _NOTIFICATION_SENDER_EMAIL: typing.Optional[str] = None
     _ADMIN_USER_EMAILS_LIST: typing.Optional[typing.List[str]] = None
+    _SERVICE_ACCT_EMAIL: typing.Optional[str] = None
     _TRUSTED_GOOGLE_PROJECTS: typing.Optional[typing.List[str]] = None
     _OIDC_AUTH0_TOKEN_CLAIM: typing.Optional[str] = None
     _OIDC_AUDIENCE: typing.Optional[typing.List[str]] = None
@@ -459,6 +460,14 @@ class Config:
         if Config._AUTH_BACKEND is None:
             Config._AUTH_BACKEND = Config._get_required_envvar("AUTH_BACKEND")
         return Config._AUTH_BACKEND
+
+    @staticmethod
+    def get_service_account_email():
+        if Config._SERVICE_ACCT_EMAIL is None:
+            ename = Config._get_required_envvar('DSS_GCP_SERVICE_ACCOUNT_NAME')
+            edomain = Config._get_required_envvar('DSS_AUTHORIZED_DOMAINS_TEST')
+            Config._SERVICE_ACCT_EMAIL = f"{ename}@{edomain}"
+        return Config._SERVICE_ACCT_EMAIL
 
     @staticmethod
     def get_ServiceAccountManager() -> security.DCPServiceAccountManager:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -106,7 +106,7 @@ def get_service_jwt(service_credentials, group: str = None, email=True, email_cl
     return signed_jwt
 
 
-def get_auth_header(real_header=True, authorized=True, group='dbio', email=True, email_claim=False):
+def get_auth_header(real_header=True, authorized=True, group='dbio', email=True, email_claim=True):
     if authorized:
         credential_file = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
         with io.open(credential_file) as fh:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -400,7 +400,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                 _notify("https://127.0.0.1")
 
     @testmode.always
-    def test_notifications_recieved(self):
+    def test_notifications_received(self):
         endpoint = self._default_endpoint()
         endpoint = NotificationRequestHandler.configure(endpoint)
         subscription_id = self.subscribe_for_notification(es_query=smartseq2_paired_ends_vx_query,
@@ -471,7 +471,14 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         url = str(UrlBuilder().set(path=f"/v1/subscriptions/{subscription_id}")
                   .add_query("replica", self.replica.name)
                   .add_query("subscription_type", "elasticsearch"))
-        self.assertDeleteResponse(url, requests.codes.ok, headers=get_auth_header())
+
+        # # TODO @chmreid
+        # # This is where we want to do a mock patch
+        # # (how to get the deleting user?)
+        # # get_auth_headers -> jwt_service_token -> various ways of populating email claim
+        # with unittest.mock.patch("dss.Config.get_admin_user_emails", return_value=[deleting_user]):
+        # # This API endpoint will check if the user is an admin, hence the patch above
+        self.assertDeleteResponse(url, requests.codes.ok, headers=get_auth_header(authorized=True))
 
     @testmode.always
     def test_subscription_notification_successful(self):
@@ -497,7 +504,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                         for payload_form_field in None, 'z':
                             # form_fields and payload_form_field are only relevant with form-data encoding
                             if encoding != MIME.json or form_fields is None and payload_form_field is None:
-                                for verify_payloads in False, True:
+                                for verify_payloads in True, False:
                                     test_case(verify_payloads=verify_payloads,
                                               method=method,
                                               encoding=encoding,

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -478,7 +478,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         # (how to get the deleting user?)
         # get_auth_header -> jwt_service_token -> various ways of populating email claim
         deleting_users = [
-            os.environ.get('DSS_GCP_SERVICE_ACCOUNT_NAME') + '@' + os.environ.get('DSS_AUTHORIZED_DOMAINS_TEST'),
+            Config.get_service_account_email(),
             UNAUTHORIZED_GCP_CREDENTIALS['client_email']
         ]
         with unittest.mock.patch("dss.Config.get_admin_user_emails", return_value=deleting_users):


### PR DESCRIPTION
Fixes the way tokens are generated in tests, to help meet requirements of the Auth0 auth backend.

(Underlying reason: every endpoint is protected by a decorator that only allows admins. The token email claim is used to look up the email address in the JWT and determine if the user is an admin.)

Part 1: unleash auth0: https://github.com/DataBiosphere/data-store/pull/146
Part 2: fix decorators for auth0: https://github.com/DataBiosphere/data-store/pull/148
Part 3: fix tests: https://github.com/DataBiosphere/data-store/pull/149
Part 4: update config: https://github.com/DataBiosphere/data-store/pull/151