### PR TITLE
[Enable Auth0 Part 4/4] DSS Config: Add config method to get Google service account email

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -116,6 +116,7 @@ class Config:
     _CURRENT_CONFIG: BucketConfig = BucketConfig.ILLEGAL
     _NOTIFICATION_SENDER_EMAIL: typing.Optional[str] = None
     _ADMIN_USER_EMAILS_LIST: typing.Optional[typing.List[str]] = None
+    _SERVICE_ACCT_EMAIL: typing.Optional[str] = None
     _TRUSTED_GOOGLE_PROJECTS: typing.Optional[typing.List[str]] = None
     _OIDC_AUTH0_TOKEN_CLAIM: typing.Optional[str] = None
     _OIDC_AUDIENCE: typing.Optional[typing.List[str]] = None
@@ -459,6 +460,14 @@ class Config:
         if Config._AUTH_BACKEND is None:
             Config._AUTH_BACKEND = Config._get_required_envvar("AUTH_BACKEND")
         return Config._AUTH_BACKEND
+
+    @staticmethod
+    def get_service_account_email():
+        if Config._SERVICE_ACCT_EMAIL is None:
+            ename = Config._get_required_envvar('DSS_GCP_SERVICE_ACCOUNT_NAME')
+            edomain = Config._get_required_envvar('DSS_AUTHORIZED_DOMAINS_TEST')
+            Config._SERVICE_ACCT_EMAIL = f"{ename}@{edomain}"
+        return Config._SERVICE_ACCT_EMAIL
 
     @staticmethod
     def get_ServiceAccountManager() -> security.DCPServiceAccountManager:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -478,7 +478,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         # (how to get the deleting user?)
         # get_auth_header -> jwt_service_token -> various ways of populating email claim
         deleting_users = [
-            os.environ.get('DSS_GCP_SERVICE_ACCOUNT_NAME') + '@' + os.environ.get('DSS_AUTHORIZED_DOMAINS_TEST'),
+            Config.get_service_account_email(),
             UNAUTHORIZED_GCP_CREDENTIALS['client_email']
         ]
         with unittest.mock.patch("dss.Config.get_admin_user_emails", return_value=deleting_users):


### PR DESCRIPTION
The indexer tests need to be able to easily get the Google service account email associated with the account running the tests. This requires pasting together two environment variables. This adds a new Config method to do that safely, and calls that method from the indexer tests.

Part 1: unleash auth0: https://github.com/DataBiosphere/data-store/pull/146
Part 2: fix decorators for auth0: https://github.com/DataBiosphere/data-store/pull/148
Part 3: fix tests: https://github.com/DataBiosphere/data-store/pull/149
Part 4: update config: https://github.com/DataBiosphere/data-store/pull/151