### PR TITLE
Assert functions should assert things and raise exceptions

### DIFF
--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -40,7 +40,7 @@ class FlacMixin(Authorize):
             return
         else:
             try:
-                assert_auth0authz_groups_intersects(flac_attributes['groups'])
+                self.assert_auth0authz_groups_intersects(flac_attributes['groups'])
             except DSSForbiddenException:
                 # Re-raise the exception with better context
                 msg = f'User: {self.token} does not have sufficient privileges for object: {flac_attributes}'

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -39,10 +39,14 @@ class FlacMixin(Authorize):
             logger.info(msg, ex)
             return
         else:
-            if not self.assert_auth0authz_groups_intersects(flac_attributes['groups']):
+            try:
+                assert_auth0authz_groups_intersects(flac_attributes['groups'])
+            except DSSForbiddenException:
+                # Re-raise the exception with better context
                 msg = f'User: {self.token} does not have sufficient privileges for object: {flac_attributes}'
                 raise DSSForbiddenException(msg)
-            return
+            else:
+                return
         # TODO what about users? should the class be able to handle users and/or groups?
 
 
@@ -80,7 +84,10 @@ class Auth0AuthZGroupsMixin(Authorize):
         has cardinality greater than zero (intersection has at least 1 member).
         """
         cardinality = len(set(self.auth0authz_groups).intersection(set(groups)))
-        return cardinality > 0
+        if cardinality > 0:
+            return
+        else:
+            raise DSSForbiddenException()
 
 
 class Auth0(FlacMixin, Auth0AuthZGroupsMixin):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -220,15 +220,16 @@ class TestAuth0Auth(unittest.TestCase):
         """
         with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
             with mock.patch('dss.util.auth.authorize.Authorize.token', token):
-                auth = AuthWrapper()
-                auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore
-                auth.security_flow(method='read')  # type: ignore
-                auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
-                if admin:
-                    auth.security_flow(method='delete')  # type: ignore
-                else:
-                    with self.assertRaises(DSSForbiddenException):
+                with mock.patch('dss.util.auth.auth0.FlacMixin._assert_authorized_flac', return_value=True):
+                    auth = AuthWrapper()
+                    auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore
+                    auth.security_flow(method='read')  # type: ignore
+                    auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
+                    if admin:
                         auth.security_flow(method='delete')  # type: ignore
+                    else:
+                        with self.assertRaises(DSSForbiddenException):
+                            auth.security_flow(method='delete')  # type: ignore
 
 
 if __name__ == "__main__":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -152,7 +152,7 @@ class TestAuthMixins(unittest.TestCase):
             self.assertEqual(a0az.auth0authz_groups, [valid_auth0authz_group])
             # Test ability to determine if A0AZ groups intersect a provided list
             all_groups = [valid_auth0authz_group, invalid_auth0authz_group]
-            self.assertTrue(a0az.assert_auth0authz_groups_intersects(all_groups))
+            a0az.assert_auth0authz_groups_intersects(all_groups)
 
 
 class TestFusilladeAuth(unittest.TestCase):


### PR DESCRIPTION
This fixes an Auth mixin class that implements an `assert_*` method that does not actually raise exceptions (returns a boolean).

This PR fixes that and updates the function calls accordingly.