### PR TITLE
Remove delete security decorators from notify v1/v2 delete endpoints

### DIFF
--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -153,7 +153,6 @@ def put(json_request_body: dict, replica: str):
     return jsonify(dict(uuid=uuid)), requests.codes.created
 
 
-@security.assert_security(method='delete', groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -153,6 +153,7 @@ def put(json_request_body: dict, replica: str):
     return jsonify(dict(uuid=uuid)), requests.codes.created
 
 
+# No security decorator needed - endpoint already checks that deletion request came from subsc owner
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -83,7 +83,6 @@ def put(json_request_body: dict, replica: str):
     return subscription_doc, requests.codes.created
 
 
-@security.assert_security(method='delete', groups=['dbio', 'public'])
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -83,6 +83,7 @@ def put(json_request_body: dict, replica: str):
     return subscription_doc, requests.codes.created
 
 
+# No security decorator needed - endpoint already checks that deletion request came from subsc owner
 def delete(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)


### PR DESCRIPTION
This PR removes the delete security decorators from the delete endpoints for v1 and v2 notifiers.

These endpoints already check the token for an email claim (which raises an Unauthorized DSSException if the email claim is not in the token) and verifies that the user requesting deletion is the owner of the subscription. So this endpoint is a special case where the "auth check" is done by the endpoint itself.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
