### PR TITLE
Remove delete security decorators from delete collections endpoints

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -156,8 +156,8 @@ def _dedpuplicate_contents(contents: List) -> List:
     return list(dedup_collection.values())
 
 
+# No security decorator needed - endpoint already checks that deletion request came from subsc owner
 @dss_handler
-@security.assert_security(method='delete', groups=['dbio'])
 def delete(uuid: str, replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 


### PR DESCRIPTION
Following #154, we need to remove the delete security decorators from the delete collections endpoint. This endpoint already performs "auth" in the sense that it raises an unauthorized exception if the JWT has no email claim, and verifies that the user requesting deletion of a collection is the owner of that collection.