### PR TITLE
Add additional "group" method to Auth0 backend to fix integration tests

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -87,7 +87,7 @@ def list_collections(per_page: int, start_at: int = 0):
 
 
 @dss_handler
-@security.assert_security(method='read', groups=['dbio'])
+@security.assert_security(method='group', groups=['dbio'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)
@@ -118,7 +118,7 @@ def put(json_request_body: dict, replica: str, uuid: str, version: str):
 
 
 @dss_handler
-@security.assert_security(method='update', groups=['dbio'])
+@security.assert_security(method='group', groups=['dbio'])
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     authenticated_user_email = security.get_token_email(request.token_info)
 

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -49,7 +49,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 
 @dss_handler
-@security.assert_security(method='read', groups=['dbio'])
+@security.assert_security(method='group', groups=['dbio'])
 def list_collections(per_page: int, start_at: int = 0):
     """
     Return a list of a user's collections.

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -19,7 +19,7 @@ from dss.config import SUBSCRIPTION_LIMIT
 logger = logging.getLogger(__name__)
 
 
-@security.assert_security(method='read', groups=['dbio', 'public'])
+@security.assert_security(method='group', groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
 

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -45,7 +45,7 @@ def get(uuid: str, replica: str):
     return jsonify(source), requests.codes.okay
 
 
-@security.assert_security(method='read', groups=['dbio', 'public'])
+@security.assert_security(method='group', groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     es_client = ElasticsearchClient.get()

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -17,7 +17,7 @@ from dss.subscriptions_v2 import (SubscriptionData,
                                   count_subscriptions_for_owner)
 
 
-@security.assert_security(method='read', groups=['dbio', 'public'])
+@security.assert_security(method='group', groups=['dbio', 'public'])
 def get(uuid: str, replica: str):
     owner = security.get_token_email(request.token_info)
     subscription = get_subscription(Replica[replica], owner, uuid)
@@ -39,7 +39,7 @@ def find(replica: str):
     return {'subscriptions': subscriptions}, requests.codes.ok
 
 
-@security.assert_security(method='create', groups=['dbio', 'public'])
+@security.assert_security(method='group', groups=['dbio', 'public'])
 def put(json_request_body: dict, replica: str):
     owner = security.get_token_email(request.token_info)
     if count_subscriptions_for_owner(Replica[replica], owner) > SUBSCRIPTION_LIMIT:

--- a/dss/api/subscriptions_v2.py
+++ b/dss/api/subscriptions_v2.py
@@ -28,7 +28,7 @@ def get(uuid: str, replica: str):
     return subscription, requests.codes.ok
 
 
-@security.assert_security(method='read', groups=['dbio', 'public'])
+@security.assert_security(method='group', groups=['dbio', 'public'])
 def find(replica: str):
     owner = security.get_token_email(request.token_info)
     subscriptions = get_subscriptions_for_owner(Replica[replica], owner)

--- a/dss/util/auth/auth0.py
+++ b/dss/util/auth/auth0.py
@@ -104,7 +104,8 @@ class Auth0(FlacMixin, Auth0AuthZGroupsMixin):
     """
     def __init__(self):
         self.session = requests.Session()
-        self.valid_methods = {'create': self._create,
+        self.valid_methods = {'group': self._group,
+                              'create': self._create,
                               'read': self._read,
                               'update': self._update,
                               'delete': self._delete}
@@ -131,6 +132,15 @@ class Auth0(FlacMixin, Auth0AuthZGroupsMixin):
         # Dispatch to correct method
         executed_method = self.valid_methods[method]
         executed_method(**kwargs)
+
+    @always_allow_admins
+    def _group(self, **kwargs):
+        """Auth checks for 'group' API actions"""
+        # This just checks that the JWT group is in the
+        # list of allowed groups specified in the decorator
+        self.assert_required_parameters(kwargs, ['groups'])
+        self._assert_authorized_group(kwargs['groups'])
+        return
 
     @always_allow_admins
     def _create(self, **kwargs):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -225,7 +225,7 @@ class TestAuth0Auth(unittest.TestCase):
                 auth.security_flow(method='group', groups=[allowed_grp])  # type: ignore
                 with mock.patch('dss.util.auth.auth0.FlacMixin._assert_authorized_flac', return_value=True):
                     auth.security_flow(method='read')  # type: ignore
-                auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
+                    auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
                 if admin:
                     auth.security_flow(method='delete')  # type: ignore
                 else:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -220,16 +220,17 @@ class TestAuth0Auth(unittest.TestCase):
         """
         with mock.patch("dss.Config.get_auth_backend", return_value="auth0"):
             with mock.patch('dss.util.auth.authorize.Authorize.token', token):
+                auth = AuthWrapper()
+                auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore
+                auth.security_flow(method='group', groups=[allowed_grp])  # type: ignore
                 with mock.patch('dss.util.auth.auth0.FlacMixin._assert_authorized_flac', return_value=True):
-                    auth = AuthWrapper()
-                    auth.security_flow(method='create', groups=[allowed_grp])  # type: ignore
                     auth.security_flow(method='read')  # type: ignore
-                    auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
-                    if admin:
+                auth.security_flow(method='update', groups=[allowed_grp])  # type: ignore
+                if admin:
+                    auth.security_flow(method='delete')  # type: ignore
+                else:
+                    with self.assertRaises(DSSForbiddenException):
                         auth.security_flow(method='delete')  # type: ignore
-                    else:
-                        with self.assertRaises(DSSForbiddenException):
-                            auth.security_flow(method='delete')  # type: ignore
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds an additional action to the Auth0 Authorize class's existing CRUD actions: "group", which is a way of checking that a user belongs to a group, that _does not_ perform a FLAC table lookup.

This is important for subscriptions/collections endpoints that need security decorators but that don't have UUIDs associated with their requests. The FLAC table lookup requires a UUID kwarg. 

This should fix integration tests to get the FLAC table lookups working.