### PR TITLE
Implement DRS Get Object for files (closes #86)

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -2408,6 +2408,7 @@ paths:
       summary: Get info about a `DrsObject`.
       description: >-
         Returns object metadata, and a list of access methods that can be used to fetch object bytes.
+        See https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.0.0/docs/
       responses:
         '200':
           description: The `DrsObject` was found successfully.
@@ -3131,7 +3132,7 @@ definitions:
           = f7a29a04
       access_methods:
         type: array
-        minItems: 0  # TODO(natanlao): should be 1
+        minItems: 1
         items:
           $ref: '#/definitions/AccessMethod'
         description: |-

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -2402,7 +2402,145 @@ paths:
                     enum: [unhandled_exception, illegal_arguments, not_found]
                 required:
                   - code
+  /ga4gh/drs/v1/objects/{object_id}:
+    get:
+      operationId: dss.api.drs.get_data_object
+      summary: Get info about a `DrsObject`.
+      description: >-
+        Returns object metadata, and a list of access methods that can be used to fetch object bytes.
+      responses:
+        '200':
+          description: The `DrsObject` was found successfully.
+          schema:
+            $ref: '#/definitions/DrsObject'
+        '202':
+          description: >
+            The operation is delayed and will continue asynchronously.
+            The client should retry this same request after the delay specified by Retry-After header.
+          headers:
+            Retry-After:
+              description: >
+                Delay in seconds. The client should retry this same request after waiting for this duration.
+                To simplify client response processing, this must be an integral relative time in seconds.
+                This value SHOULD represent the minimum duration the client should wait before attempting
+                the operation again with a reasonable expectation of success. When it is not feasible
+                for the server to determine the actual expected delay, the server may return a
+                brief, fixed value instead.
+              type: integer
+              format: int64
+        400:
+          description: Bad request
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
 
+                      The code `illegal_token` is returned when the token parameter cannot be understood.
+                    enum: [illegal_token]
+                required:
+                  - code
+        401:
+          description: Unauthorized user is attempting this action.
+          schema:
+            allOf:
+            - $ref: '#/definitions/Error'
+            - type: object
+              properties:
+                code:
+                  type: string
+                  description: Machine-readable error code.  The types of return values should not be changed lightly.
+                  enum: [Unauthorized]
+              required:
+              - code
+        403:
+          description: Unauthorized user is attempting this action.
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [Forbidden]
+                required:
+                  - code
+        404:
+          description: >
+            Returned when the server could not find the requested resource.
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [not_found]
+                required:
+                  - code
+        500:
+          $ref: '#/responses/ServerError'
+        502:
+          $ref: '#/responses/BadGateway'
+        503:
+          $ref: '#/responses/ServiceUnavailable'
+        504:
+          $ref: '#/responses/GatewayTimeout'
+        default:
+          description: Unexpected error
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [unhandled_exception, illegal_arguments]
+                required:
+                  - code
+      parameters:
+        - name: object_id
+          in: path
+          required: true
+          type: string
+        - name: version
+          in: query
+          description: Timestamp of bundle creation in DSS_VERSION format.
+          required: false
+          type: string
+        - name: replica
+          in: query
+          description: Replica to fetch from.
+          required: false
+          type: string
+          default: aws
+          enum: [aws, gcp]
+        - in: query
+          name: expand
+          type: boolean
+          default: false
+          description: >-
+            If false and the object_id refers to a bundle, then the ContentsObject array
+            contains only those objects directly contained in the bundle. That is, if the
+            bundle contains other bundles, those other bundles are not recursively
+            included in the result.
+
+            If true and the object_id refers to a bundle, then the entire set of objects
+            in the bundle is expanded. That is, if the bundle contains aother bundles,
+            then those other bundles are recursively expanded and included in the result.
+            Recursion continues through the entire sub-tree of the bundle.
+
+            If the object_id refers to a blob, then the query parameter is ignored.
+      tags:
+        - DataRepositoryService
 definitions:
   File:
     type: object
@@ -2908,6 +3046,226 @@ definitions:
     properties:
       files:
         type: string
+  DrsObject:
+    type: object
+    required: ['id', 'self_uri', 'size', 'created_time', 'checksums']
+    properties:
+      id:
+        type: string
+        description: |-
+          An identifier unique to this `DrsObject`.
+      name:
+        type: string
+        description: A RFC4122-compliant ID for the object.
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+      self_uri:
+        type: string
+        description: |-
+          A drs:// URI, as defined in the DRS documentation, that tells clients how to access this object.
+          The intent of this field is to make DRS objects self-contained, and therefore easier for clients to store and pass around.
+        example:
+          drs://drs.example.org/314159
+      size:
+        type: integer
+        format: int64
+        description: |-
+          For blobs, the blob size in bytes.
+          For bundles, the cumulative size, in bytes, of items in the `contents` field.
+      created_time:
+        type: string
+        format: date-time
+        description: |-
+          Timestamp of content creation in RFC3339.
+          (This is the creation time of the underlying content, not of the JSON object.)
+      updated_time:
+        type: string
+        format: date-time
+        description: >-
+          Timestamp of content update in RFC3339, identical to `created_time` in systems
+          that do not support updates.
+          (This is the update time of the underlying content, not of the JSON object.)
+      version:
+        format: DSS_VERSION
+        description: >-
+          A string representing a version.
+      mime_type:
+        type: string
+        description: |-
+          A string providing the mime-type of the `DrsObject`.
+        example:
+          application/json
+      checksums:
+        type: array
+        minItems: 1
+        items:
+          $ref: '#/definitions/Checksum'
+        description: >-
+          The checksum of the `DrsObject`. At least one checksum must be provided.
+
+          For blobs, the checksum is computed over the bytes in the blob.
+
+
+          For bundles, the checksum is computed over a sorted concatenation of the
+          checksums of its top-level contained objects (not recursive, names not included).
+          The list of checksums is sorted alphabetically (hex-code) before concatenation
+          and a further checksum is performed on the concatenated checksum value.
+
+
+          For example, if a bundle contains blobs with the following checksums:
+
+          md5(blob1) = 72794b6d
+
+          md5(blob2) = 5e089d29
+
+
+          Then the checksum of the bundle is:
+
+          md5( concat( sort( md5(blob1), md5(blob2) ) ) )
+
+          = md5( concat( sort( 72794b6d, 5e089d29 ) ) )
+
+          = md5( concat( 5e089d29, 72794b6d ) )
+
+          = md5( 5e089d2972794b6d )
+
+          = f7a29a04
+      access_methods:
+        type: array
+        minItems: 0  # TODO(natanlao): should be 1
+        items:
+          $ref: '#/definitions/AccessMethod'
+        description: |-
+          The list of access methods that can be used to fetch the `DrsObject`.
+          Required for single blobs; optional for bundles.
+      contents:
+        type: array
+        description: >-
+          If not set, this `DrsObject` is a single blob.
+
+          If set, this `DrsObject` is a bundle containing the listed `ContentsObject` s (some of which may be further nested).
+        items:
+          $ref: '#/definitions/ContentsObject'
+      description:
+        type: string
+        description: |-
+          A human readable description of the `DrsObject`.
+      aliases:
+        type: array
+        items:
+          type: string
+        description: >-
+          A list of strings that can be used to find other metadata
+          about this `DrsObject` from external metadata sources. These
+          aliases can be used to represent secondary
+          accession numbers or external GUIDs.
+  AccessMethod:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+        - s3
+        - gs
+        - ftp
+        - gsiftp
+        - globus
+        - htsget
+        - https
+        - file
+        description: >-
+          Type of the access method.
+      access_url:
+        $ref: '#/definitions/AccessURL'
+        description: >-
+          An `AccessURL` that can be used to fetch the actual object bytes.
+          Note that at least one of `access_url` and `access_id` must be provided.
+      access_id:
+        type: string
+        description: >-
+          An arbitrary string to be passed to the `/access` method to get an `AccessURL`.
+          This string must be unique within the scope of a single object.
+          Note that at least one of `access_url` and `access_id` must be provided.
+      region:
+        type: string
+        description: >-
+          Name of the region in the cloud service provider that the object belongs to.
+        example:
+          us-east-1
+  AccessURL:
+    type: object
+    required: ['url']
+    properties:
+      url:
+        type: string
+        description: A fully resolvable URL that can be used to fetch the actual object bytes.
+      headers:
+        type: array
+        items:
+          type: string
+        description: >-
+          An optional list of headers to include in the HTTP request to `url`.
+          These headers can be used to provide auth tokens required to fetch the object bytes.
+        example:
+          Authorization: Basic Z2E0Z2g6ZHJz
+  ContentsObject:
+    type: object
+    properties:
+      name:
+        type: string
+        description: >-
+          A name declared by the bundle author that must be
+          used when materialising this object,
+          overriding any name directly associated with the object itself.
+          The name must be unique with the containing bundle.
+          This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
+      id:
+        type: string
+        description: >-
+          A DRS identifier of a `DrsObject` (either a single blob or a nested bundle).
+          If this ContentsObject is an object within a nested bundle, then the id is
+          optional. Otherwise, the id is required.
+      drs_uri:
+        type: array
+        description: >-
+          A list of full DRS identifier URI paths
+          that may be used to obtain the object.
+          These URIs may be external to this DRS instance.
+        example:
+          drs://drs.example.org/314159
+        items:
+          type: string
+      contents:
+        type: array
+        description: >-
+          If this ContentsObject describes a nested bundle and the caller specified
+          "?expand=true" on the request, then this contents array must be present and
+          describe the objects within the nested bundle.
+        items:
+          $ref: '#/definitions/ContentsObject'
+    required:
+      - name
+  Checksum:
+    type: object
+    required: ['checksum', 'type']
+    properties:
+      checksum:
+        type: string
+        description: 'The hex-string encoded checksum for the data'
+      type:
+        type: string
+        description: >-
+          The digest method used to create the checksum.
+
+          The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg[IANA Named Information Hash Algorithm Registry].
+          Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
+
+          GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
+          Until then, if implementors do choose such an algorithm (e.g. because it's implemented by their storage provider), they SHOULD use an existing
+          standard `type` value such as `md5`, `etag`, `crc32c`, `trunc512`, or `sha1`.
+        example:
+          sha-256
 
 responses:
   ServerError:

--- a/dss/api/drs.py
+++ b/dss/api/drs.py
@@ -17,7 +17,6 @@ def get_data_object(object_id: str):
     https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.0.0/docs/
     """
     # This only implements file access for now. As such, `expand` is ignored
-    # `access_url` is also not implemented, pending FLAC work
     version = request.args.get("version", None)
     replica = request.args.get("replica", "aws")
     req = get_helper(object_id, replica=Replica[replica], version=version)
@@ -39,7 +38,12 @@ def get_data_object(object_id: str):
             {'checksum': req.headers['x-dss-crc32c'],
              'type': 'crc32c'}
         ],
-        'access_methods': [],
+        'access_methods': [{
+            'type': 's3' if replica == 'aws' else 'gcp',
+            'access_url': {
+                'url': req.headers['Location']
+            }
+        }],
         'created_time': datetime_from_timestamp(req.headers['x-dss-version']),
         'updated_time': datetime_from_timestamp(req.headers['x-dss-version']),
         'id': object_id,

--- a/dss/api/drs.py
+++ b/dss/api/drs.py
@@ -1,0 +1,52 @@
+import os
+import requests
+
+from flask import jsonify, make_response, request
+
+from dss import dss_handler
+from dss.api.files import get_helper
+from dss.config import Replica
+from dss.util.version import datetime_from_timestamp
+
+
+@dss_handler
+def get_data_object(object_id: str):
+    """
+    Translates a DRS data object request to a DSS GET/HEAD file request.
+    See the Data Repository Service schema here:
+    https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.0.0/docs/
+    """
+    # This only implements file access for now. As such, `expand` is ignored
+    # `access_url` is also not implemented, pending FLAC work
+    version = request.args.get("version", None)
+    replica = request.args.get("replica", "aws")
+    req = get_helper(object_id, replica=Replica[replica], version=version)
+    if req.status_code == 301:
+        req.status_code = 202
+        return req
+    elif req.status_code != 302:  # For errors, just proxy DSS response
+        return req
+    version = (f'&version={version}' if version is not None else '')
+    self_url = f"drs://{os.environ['API_DOMAIN_NAME']}/v1/ga4gh/drs/v1/objects/{object_id}?replica={replica}" + version
+    resp = {
+        'checksums': [
+            {'checksum': req.headers['x-dss-sha1'],
+             'type': 'sha1'},
+            {'checksum': req.headers['x-dss-sha256'],
+             'type': 'sha256'},
+            {'checksum': req.headers['x-dss-s3-etag'],
+             'type': 's3-etag'},
+            {'checksum': req.headers['x-dss-crc32c'],
+             'type': 'crc32c'}
+        ],
+        'access_methods': [],
+        'created_time': datetime_from_timestamp(req.headers['x-dss-version']),
+        'updated_time': datetime_from_timestamp(req.headers['x-dss-version']),
+        'id': object_id,
+        'name': object_id,
+        'self_uri': self_url,
+        'size': int(req.headers['x-dss-size']),
+        'version': req.headers['x-dss-version'],
+        'mime_type': req.headers['x-dss-content-type'],
+    }
+    return make_response(jsonify(resp), requests.codes.ok)

--- a/scripts/swagger_auth.py
+++ b/scripts/swagger_auth.py
@@ -31,6 +31,7 @@ full_auth = {"/search": ["post"],
              "/bundles/checkout/{checkout_job_id}": ["get"],
              "/events": ["get"],
              "/events/{uuid}": ["get"],
+             "/ga4gh/drs/v1/objects/{object_id}": ["get"],
             }
 
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -382,6 +382,32 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
         self._test_file_head(Replica.aws)
         self._test_file_head(Replica.gcp)
 
+    def test_drs_file_head(self):
+        # This is _test_file_head() copied and pasted and tweaked to test
+        # the DRS response.
+        file_uuid = "ce55fd51-7833-469b-be0b-5da88ebebfcd"
+        version = "2017-06-16T193604.240704Z"
+        headers = {'X-DSS-CREATOR-UID': '4321',
+                   'X-DSS-VERSION': version,
+                   'X-DSS-CONTENT-TYPE': 'text/plain',
+                   'X-DSS-SIZE': '8685',
+                   'X-DSS-CRC32C': 'e16e07b9',
+                   'X-DSS-S3-ETAG': '3b83ef96387f14655fc854ddc3c6bd57',
+                   'X-DSS-SHA1': '2b8b815229aa8a61e483fb4ba0588b8b6c491890',
+                   'X-DSS-SHA256': 'cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30',
+                   }
+        url = str(UrlBuilder()
+                  .set(path="/v1/ga4gh/drs/v1/objects/" + file_uuid))
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
+            resp_obj = self.assertGetResponse(
+                url,
+                [requests.codes.ok],
+                headers=get_auth_header()
+            )
+        self.assertEqual(int(headers['X-DSS-SIZE']), resp_obj.json['size'])
+        self.assertEqual(resp_obj.json['id'], file_uuid)
+        self.assertEqual(headers['X-DSS-CONTENT-TYPE'], resp_obj.json['mime_type'])
+
     def _test_file_head(self, replica: Replica):
         file_uuid = "ce55fd51-7833-469b-be0b-5da88ebebfcd"
         version = "2017-06-16T193604.240704Z"


### PR DESCRIPTION
Implements partial support for the DRS Get Object endpoint. This
implementation does not permit using the Get Object endpoint to
retrieve information on bundles or collections, and is missing
access information due to ongoing access control work.

Closes #86 
<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
